### PR TITLE
Add GitHub Actions CI/CD pipeline for subgraph

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: Subgraph CI/CD
+
+on:
+  pull_request:
+    branches: [main]
+    paths: ['pop-subgraph/**']
+  push:
+    branches: [main]
+    paths: ['pop-subgraph/**']
+
+env:
+  WORKING_DIRECTORY: pop-subgraph
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+          cache-dependency-path: ${{ env.WORKING_DIRECTORY }}/yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Generate code from GraphQL schema
+        run: yarn codegen
+
+      - name: Build subgraph
+        run: yarn build
+
+      - name: Run tests
+        run: yarn test
+
+  deploy:
+    name: Deploy to The Graph Studio
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    defaults:
+      run:
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'yarn'
+          cache-dependency-path: ${{ env.WORKING_DIRECTORY }}/yarn.lock
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Generate code from GraphQL schema
+        run: yarn codegen
+
+      - name: Build subgraph
+        run: yarn build
+
+      - name: Authenticate with The Graph Studio
+        run: yarn graph auth --studio ${{ secrets.GRAPH_DEPLOY_KEY }}
+
+      - name: Deploy subgraph
+        run: |
+          VERSION_LABEL=$(echo ${{ github.sha }} | cut -c1-7)
+          yarn graph deploy --studio --version-label $VERSION_LABEL poa-2


### PR DESCRIPTION
Implements automated testing on PR and deployment to The Graph Studio on merge to main.

## Features
- **On PR to main**: Runs codegen, build, and tests
- **On merge to main**: Runs all checks and deploys with commit SHA version label
- Uses Yarn for dependency management with caching
- Targets The Graph Studio deployment of `poa-2` subgraph

## Setup Required
Add `GRAPH_DEPLOY_KEY` secret to GitHub repository with your deploy key from The Graph Studio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)