### PR TITLE
fix: Correct event ordering for OrgRegistered and OrgDeployed

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -1,21 +1,22 @@
 type Organization @entity(immutable: false) {
   id: Bytes! # orgId
-  orgId: Bytes!
-  executorContract: ExecutorContract! # Relationship to ExecutorContract entity
-  hybridVoting: HybridVotingContract! # Relationship to HybridVotingContract entity
-  directDemocracyVoting: DirectDemocracyVotingContract! # Relationship to DirectDemocracyVotingContract entity
-  quickJoin: QuickJoinContract! # Relationship to QuickJoinContract entity
-  participationToken: ParticipationTokenContract! # Relationship to ParticipationTokenContract entity
-  taskManager: TaskManager! # Relationship to TaskManager entity
-  educationHub: EducationHubContract! # Relationship to EducationHubContract entity
-  paymentManager: PaymentManagerContract! # Relationship to PaymentManagerContract entity
-  eligibilityModule: EligibilityModuleContract! # Relationship to EligibilityModuleContract entity
-  toggleModuleContract: ToggleModuleContract! # Relationship to ToggleModuleContract entity
-  topHatId: BigInt!
-  roleHatIds: [BigInt!]!
-  deployedAt: BigInt!
-  deployedAtBlock: BigInt!
-  transactionHash: Bytes!
+  # Contract relationships - nullable because OrgRegistered creates org before OrgDeployed adds contracts
+  executorContract: ExecutorContract
+  hybridVoting: HybridVotingContract
+  directDemocracyVoting: DirectDemocracyVotingContract
+  quickJoin: QuickJoinContract
+  participationToken: ParticipationTokenContract
+  taskManager: TaskManager
+  educationHub: EducationHubContract
+  paymentManager: PaymentManagerContract
+  eligibilityModule: EligibilityModuleContract
+  toggleModuleContract: ToggleModuleContract
+  # Deployment data - nullable until OrgDeployed event
+  topHatId: BigInt
+  roleHatIds: [BigInt!]
+  deployedAt: BigInt
+  deployedAtBlock: BigInt
+  transactionHash: Bytes
   users: [User!]! @derivedFrom(field: "organization")
   # Consolidated entity references
   hatPermissions: [HatPermission!]! @derivedFrom(field: "organization")

--- a/pop-subgraph/src/org-deployer.ts
+++ b/pop-subgraph/src/org-deployer.ts
@@ -118,9 +118,11 @@ export function handleOrgDeployed(event: OrgDeployed): void {
   toggleModule.createdAt = event.block.timestamp;
   toggleModule.createdAtBlock = event.block.number;
 
-  // Create Organization entity
-  let organization = new Organization(event.params.orgId);
-  organization.orgId = event.params.orgId;
+  // Load existing Organization (created by OrgRegistered) or create new one
+  let organization = Organization.load(event.params.orgId);
+  if (!organization) {
+    organization = new Organization(event.params.orgId);
+  }
   organization.executorContract = executor.id; // Link to ExecutorContract entity
   organization.hybridVoting = hybridVoting.id; // Link to HybridVotingContract entity
   organization.directDemocracyVoting = directDemocracyVoting.id; // Link to DirectDemocracyVotingContract entity

--- a/pop-subgraph/src/org-registry.ts
+++ b/pop-subgraph/src/org-registry.ts
@@ -51,15 +51,15 @@ export function handleOrgRegistered(event: OrgRegisteredEvent): void {
   registry.totalOrgs = registry.totalOrgs.plus(BigInt.fromI32(1));
   registry.save();
 
-  // Load Organization (should exist from OrgDeployed event)
+  // Load or create Organization (OrgRegistered may fire before OrgDeployed)
   let org = Organization.load(orgId);
-  if (org) {
-    // Update org with registry data
-    org.name = name;
-    org.metadataHash = metadataHash;
-    org.lastUpdatedAt = event.block.timestamp;
-    org.save();
+  if (!org) {
+    org = new Organization(orgId);
   }
+  org.name = name;
+  org.metadataHash = metadataHash;
+  org.lastUpdatedAt = event.block.timestamp;
+  org.save();
 }
 
 /**

--- a/pop-subgraph/src/utils.ts
+++ b/pop-subgraph/src/utils.ts
@@ -212,7 +212,7 @@ export function recordUserHatChange(
 export function getOrgIdFromContract(contractAddress: Address): Bytes | null {
   let org = Organization.load(contractAddress);
   if (org) {
-    return org.orgId;
+    return org.id;
   }
   return null;
 }

--- a/pop-subgraph/tests/executor.test.ts
+++ b/pop-subgraph/tests/executor.test.ts
@@ -54,7 +54,6 @@ function setupExecutorEntities(): void {
     "0x1111111111111111111111111111111111111111111111111111111111111111"
   );
   let organization = new Organization(orgId);
-  organization.orgId = orgId;
   organization.topHatId = BigInt.fromI32(1000);
   organization.roleHatIds = [BigInt.fromI32(1001), BigInt.fromI32(1002)];
   organization.deployedAt = BigInt.fromI32(1000);

--- a/pop-subgraph/tests/hybrid-voting.test.ts
+++ b/pop-subgraph/tests/hybrid-voting.test.ts
@@ -44,7 +44,6 @@ function setupHybridVotingContract(contractAddress: Address): void {
     "0x1111111111111111111111111111111111111111111111111111111111111111"
   );
   let organization = new Organization(orgId);
-  organization.orgId = orgId;
   organization.topHatId = BigInt.fromI32(1000);
   organization.roleHatIds = [BigInt.fromI32(1001), BigInt.fromI32(1002)];
   organization.deployedAt = BigInt.fromI32(1000);

--- a/pop-subgraph/tests/org-registry.test.ts
+++ b/pop-subgraph/tests/org-registry.test.ts
@@ -33,7 +33,6 @@ const REGISTRY_ADDRESS = "0xa16081f360e3847006db660bae1c6d1b2e17ec2a";
 // Helper to create Organization entity (normally created by OrgDeployed)
 function createMockOrganization(orgId: Bytes): void {
   let org = new Organization(orgId);
-  org.orgId = orgId;
   // Required fields - mock addresses
   org.executorContract = Bytes.fromHexString("0x0000000000000000000000000000000000000001");
   org.hybridVoting = Bytes.fromHexString("0x0000000000000000000000000000000000000002");

--- a/pop-subgraph/tests/task-manager.test.ts
+++ b/pop-subgraph/tests/task-manager.test.ts
@@ -40,7 +40,6 @@ function setupTaskManagerEntities(): void {
     "0x1111111111111111111111111111111111111111111111111111111111111111"
   );
   let organization = new Organization(orgId);
-  organization.orgId = orgId;
   organization.topHatId = BigInt.fromI32(1000);
   organization.roleHatIds = [BigInt.fromI32(1001), BigInt.fromI32(1002)];
   organization.deployedAt = BigInt.fromI32(1000);

--- a/pop-subgraph/tests/toggle-module.test.ts
+++ b/pop-subgraph/tests/toggle-module.test.ts
@@ -40,7 +40,6 @@ function setupToggleModuleEntities(): void {
     "0x1111111111111111111111111111111111111111111111111111111111111111"
   );
   let organization = new Organization(orgId);
-  organization.orgId = orgId;
   organization.topHatId = BigInt.fromI32(1000);
   organization.roleHatIds = [BigInt.fromI32(1001), BigInt.fromI32(1002)];
   organization.deployedAt = BigInt.fromI32(1000);


### PR DESCRIPTION
## Summary
- OrgRegistered fires BEFORE OrgDeployed in the same transaction, causing null values for `name`, `metadataHash`, and `lastUpdatedAt` on Organization entities
- Updated handlers so OrgRegistered creates the Organization with registry data, and OrgDeployed loads the existing org and adds contract references
- Removed redundant `orgId` field from Organization (the `id` field already serves this purpose)
- Made contract relationship fields nullable to support the new event ordering

## Changes
- `schema.graphql`: Made Organization contract relationships and deployment fields nullable
- `src/org-registry.ts`: Updated `handleOrgRegistered` to create Organization if it doesn't exist
- `src/org-deployer.ts`: Updated `handleOrgDeployed` to load existing Organization
- `src/utils.ts`: Changed `org.orgId` to `org.id`
- Tests: Removed `organization.orgId = orgId` assignments

## Test plan
- [x] All 73 tests pass
- [ ] Deploy to hoodi and verify Organization entities have correct name/metadataHash values

🤖 Generated with [Claude Code](https://claude.com/claude-code)