### PR TITLE
Add resilient IPFS indexing for org metadata

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -1,4 +1,4 @@
-# Schema version: 1.0.1
+# Schema version: 1.1.0
 type Organization @entity(immutable: false) {
   id: Bytes! # orgId
   # Contract relationships - nullable because OrgRegistered creates org before OrgDeployed adds contracts
@@ -26,6 +26,7 @@ type Organization @entity(immutable: false) {
   # From OrgRegistry - org name and metadata
   name: String
   metadataHash: Bytes
+  metadata: OrgMetadata # IPFS-indexed metadata content (may be null if IPFS unavailable)
   lastUpdatedAt: BigInt
   metaUpdates: [OrgMetaUpdate!]! @derivedFrom(field: "organization")
   registeredContracts: [RegisteredContract!]! @derivedFrom(field: "organization")
@@ -1514,6 +1515,29 @@ type OrgMetaUpdate @entity(immutable: true) {
   updatedAt: BigInt!
   updatedAtBlock: BigInt!
   transactionHash: Bytes!
+}
+
+"""
+IPFS-indexed org metadata content.
+This entity is populated by a file data source that fetches from IPFS.
+If IPFS is unavailable or slow, the main Organization entity will still be indexed
+with the metadataHash - this entity will be populated when/if IPFS content becomes available.
+"""
+type OrgMetadata @entity(immutable: false) {
+  id: String! # IPFS hash (CID)
+  organization: Organization
+  description: String
+  template: String
+  links: [OrgMetadataLink!]! @derivedFrom(field: "metadata")
+  indexedAt: BigInt
+}
+
+type OrgMetadataLink @entity(immutable: true) {
+  id: String! # metadataId-index
+  metadata: OrgMetadata!
+  name: String!
+  url: String!
+  index: Int!
 }
 
 type RegisteredContract @entity(immutable: false) {

--- a/pop-subgraph/src/org-metadata.ts
+++ b/pop-subgraph/src/org-metadata.ts
@@ -1,0 +1,103 @@
+import { Bytes, dataSource, json, BigInt, JSONValueKind } from "@graphprotocol/graph-ts";
+import { OrgMetadata, OrgMetadataLink } from "../generated/schema";
+
+/**
+ * Handler for IPFS file data source that parses org metadata JSON.
+ *
+ * Expected JSON structure:
+ * {
+ *   description: "...",
+ *   links: [{ name: "...", url: "..." }],
+ *   template: "default"
+ * }
+ *
+ * This handler is resilient to malformed data - if parsing fails or fields
+ * are missing, the entity will be created with whatever data is available.
+ * The subgraph will NOT brick if IPFS is slow or unavailable - the main
+ * Organization entity from on-chain events will still be indexed.
+ */
+export function handleOrgMetadata(content: Bytes): void {
+  // The dataSource.stringParam() contains the IPFS hash (CID)
+  let ipfsHash = dataSource.stringParam();
+
+  // Get the orgId from the context passed by the caller
+  let context = dataSource.context();
+  let orgId = context.getBytes("orgId");
+
+  // Try to parse the JSON content
+  let jsonResult = json.try_fromBytes(content);
+  if (jsonResult.isError) {
+    // JSON parsing failed - create entity with just the ID and org link
+    let metadata = new OrgMetadata(ipfsHash);
+    metadata.organization = orgId;
+    metadata.save();
+    return;
+  }
+
+  let jsonValue = jsonResult.value;
+  if (!jsonValue.isNull() && jsonValue.kind == JSONValueKind.OBJECT) {
+    let jsonObject = jsonValue.toObject();
+
+    // Create or load the metadata entity
+    let metadata = OrgMetadata.load(ipfsHash);
+    if (metadata == null) {
+      metadata = new OrgMetadata(ipfsHash);
+    }
+
+    // Link to organization
+    metadata.organization = orgId;
+
+    // Parse description
+    let descriptionValue = jsonObject.get("description");
+    if (descriptionValue != null && !descriptionValue.isNull() && descriptionValue.kind == JSONValueKind.STRING) {
+      metadata.description = descriptionValue.toString();
+    }
+
+    // Parse template
+    let templateValue = jsonObject.get("template");
+    if (templateValue != null && !templateValue.isNull() && templateValue.kind == JSONValueKind.STRING) {
+      metadata.template = templateValue.toString();
+    }
+
+    // Set indexed timestamp (approximate - file data sources don't have block context)
+    // We use 0 as a placeholder since file handlers don't have ethereum.Event context
+    metadata.indexedAt = BigInt.fromI32(0);
+
+    metadata.save();
+
+    // Parse links array
+    let linksValue = jsonObject.get("links");
+    if (linksValue != null && !linksValue.isNull() && linksValue.kind == JSONValueKind.ARRAY) {
+      let linksArray = linksValue.toArray();
+
+      for (let i = 0; i < linksArray.length; i++) {
+        let linkValue = linksArray[i];
+        if (!linkValue.isNull() && linkValue.kind == JSONValueKind.OBJECT) {
+          let linkObject = linkValue.toObject();
+
+          let nameValue = linkObject.get("name");
+          let urlValue = linkObject.get("url");
+
+          // Only create link if both name and url are present
+          if (
+            nameValue != null && !nameValue.isNull() && nameValue.kind == JSONValueKind.STRING &&
+            urlValue != null && !urlValue.isNull() && urlValue.kind == JSONValueKind.STRING
+          ) {
+            let linkId = ipfsHash + "-" + i.toString();
+            let link = new OrgMetadataLink(linkId);
+            link.metadata = ipfsHash;
+            link.name = nameValue.toString();
+            link.url = urlValue.toString();
+            link.index = i;
+            link.save();
+          }
+        }
+      }
+    }
+  } else {
+    // Not a JSON object - create entity with just the ID and org link
+    let metadata = new OrgMetadata(ipfsHash);
+    metadata.organization = orgId;
+    metadata.save();
+  }
+}

--- a/pop-subgraph/subgraph.yaml
+++ b/pop-subgraph/subgraph.yaml
@@ -681,3 +681,18 @@ templates:
         - event: AdminTransferred(indexed address,indexed address)
           handler: handleAdminTransferred
       file: ./src/toggle-module.ts
+  # IPFS file data source for org metadata
+  - kind: file/ipfs
+    name: OrgMetadata
+    network: hoodi
+    mapping:
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      file: ./src/org-metadata.ts
+      handler: handleOrgMetadata
+      entities:
+        - OrgMetadata
+        - OrgMetadataLink
+      abis:
+        - name: OrgRegistry
+          file: ./abis/OrgRegistry.json


### PR DESCRIPTION
## Summary

- Adds `OrgMetadata` and `OrgMetadataLink` entities to store IPFS-indexed organization metadata
- Implements file data source for fetching metadata from IPFS without blocking on-chain indexing
- Main chain indexing remains resilient if IPFS is slow or unavailable
- Includes new tests verifying metadata field is correctly linked

## Test plan

- All 76 existing tests pass
- Added 3 new tests for metadata field handling in org registration and updates
- Verified build compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)