### PR TITLE
Fix role filtering to exclude system contracts

### DIFF
--- a/pop-subgraph/src/eligibility-module.ts
+++ b/pop-subgraph/src/eligibility-module.ts
@@ -34,7 +34,8 @@ import {
   linkHatToRole,
   getOrCreateRoleWearer,
   linkWearerEligibilityToRoleWearer,
-  recordUserHatChange
+  recordUserHatChange,
+  shouldCreateRoleWearer
 } from "./utils";
 
 export function handleEligibilityModuleInitialized(
@@ -387,21 +388,24 @@ export function handleHatClaimed(event: HatClaimedEvent): void {
     );
     claim.wearerUser = user.id;
 
-    // Create RoleWearer entity
-    getOrCreateRoleWearer(
-      eligibilityModule.organization,
-      hatId,
-      event.params.wearer,
-      event
-    );
+    // Only create RoleWearer for user-facing hats to non-system addresses
+    if (shouldCreateRoleWearer(eligibilityModule.organization, hatId, event.params.wearer)) {
+      // Create RoleWearer entity
+      getOrCreateRoleWearer(
+        eligibilityModule.organization,
+        hatId,
+        event.params.wearer,
+        event
+      );
 
-    // Record the hat change on the user
-    recordUserHatChange(user, hatId, true, event);
+      // Record the hat change on the user
+      recordUserHatChange(user, hatId, true, event);
 
-    // Update join method if this is their first hat
-    if (user.joinMethod == null) {
-      user.joinMethod = "HatClaim";
-      user.save();
+      // Update join method if this is their first hat
+      if (user.joinMethod == null) {
+        user.joinMethod = "HatClaim";
+        user.save();
+      }
     }
   }
 

--- a/pop-subgraph/src/quick-join.ts
+++ b/pop-subgraph/src/quick-join.ts
@@ -14,7 +14,7 @@ import {
   QuickJoinEvent,
   QuickJoinAddressUpdate
 } from "../generated/schema";
-import { createExecutorChange, getOrCreateRole, getOrCreateRoleWearer, getOrCreateUser, recordUserHatChange } from "./utils";
+import { createExecutorChange, getOrCreateRole, getOrCreateRoleWearer, getOrCreateUser, recordUserHatChange, shouldCreateRoleWearer } from "./utils";
 
 export function handleInitialized(event: InitializedEvent): void {
   // Initialization is handled by OrgDeployer when the contract is created.
@@ -48,7 +48,7 @@ export function handleQuickJoined(event: QuickJoinedEvent): void {
 
   joinEvent.save();
 
-  // Create RoleWearer entities for each hat
+  // Create RoleWearer entities for each hat (only for user-facing hats to non-system addresses)
   let contract = QuickJoinContract.load(contractAddress);
   if (contract) {
     let user = getOrCreateUser(
@@ -60,8 +60,11 @@ export function handleQuickJoined(event: QuickJoinedEvent): void {
 
     let hatIds = event.params.hatIds;
     for (let i = 0; i < hatIds.length; i++) {
-      getOrCreateRoleWearer(contract.organization, hatIds[i], event.params.user, event);
-      recordUserHatChange(user, hatIds[i], true, event);
+      // Only create RoleWearer for eligible combinations
+      if (shouldCreateRoleWearer(contract.organization, hatIds[i], event.params.user)) {
+        getOrCreateRoleWearer(contract.organization, hatIds[i], event.params.user, event);
+        recordUserHatChange(user, hatIds[i], true, event);
+      }
     }
 
     // Update join method
@@ -89,7 +92,7 @@ export function handleQuickJoinedByMaster(event: QuickJoinedByMasterEvent): void
 
   joinEvent.save();
 
-  // Create RoleWearer entities for each hat
+  // Create RoleWearer entities for each hat (only for user-facing hats to non-system addresses)
   let contract = QuickJoinContract.load(contractAddress);
   if (contract) {
     let user = getOrCreateUser(
@@ -101,8 +104,11 @@ export function handleQuickJoinedByMaster(event: QuickJoinedByMasterEvent): void
 
     let hatIds = event.params.hatIds;
     for (let i = 0; i < hatIds.length; i++) {
-      getOrCreateRoleWearer(contract.organization, hatIds[i], event.params.user, event);
-      recordUserHatChange(user, hatIds[i], true, event);
+      // Only create RoleWearer for eligible combinations
+      if (shouldCreateRoleWearer(contract.organization, hatIds[i], event.params.user)) {
+        getOrCreateRoleWearer(contract.organization, hatIds[i], event.params.user, event);
+        recordUserHatChange(user, hatIds[i], true, event);
+      }
     }
 
     // Update join method


### PR DESCRIPTION
## Summary
Prevent Executor and EligibilityModule contracts from being incorrectly indexed as organization RoleWearers when they receive hats during deployment. Implements event-based filtering that checks both the wearer address (to exclude system contracts) and hat ID (to exclude system hats).

## Changes
- Add three filtering utilities: `isSystemContract()`, `isUserFacingRoleHat()`, `shouldCreateRoleWearer()`
- Apply filtering in HatsMinted, HatClaimed, QuickJoined, and QuickJoinedByMaster event handlers

## Test Status
All 109 tests pass, including 33 new comprehensive role filtering tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)