### PR TITLE
Fix timing issue: skip RoleWearer for self-minting contracts

### DIFF
--- a/pop-subgraph/src/eligibility-module.ts
+++ b/pop-subgraph/src/eligibility-module.ts
@@ -380,6 +380,13 @@ export function handleHatClaimed(event: HatClaimedEvent): void {
   // Link to User entity and create RoleWearer
   let eligibilityModule = EligibilityModuleContract.load(contractAddress);
   if (eligibilityModule) {
+    // Skip RoleWearer creation if EligibilityModule is claiming for itself (system contract)
+    // This avoids timing issues with Organization entity not being fully saved yet
+    if (event.params.wearer.equals(contractAddress)) {
+      claim.save();
+      return;
+    }
+
     let user = getOrCreateUser(
       eligibilityModule.organization,
       event.params.wearer,

--- a/pop-subgraph/src/executor.ts
+++ b/pop-subgraph/src/executor.ts
@@ -198,6 +198,13 @@ export function handleHatsMinted(event: HatsMintedEvent): void {
   // Link to User entity if we can determine the organization
   let executor = ExecutorContract.load(contractAddress);
   if (executor) {
+    // Skip RoleWearer creation if Executor is minting to itself (system contract)
+    // This avoids timing issues with Organization entity not being fully saved yet
+    if (recipient.equals(contractAddress)) {
+      mint.save();
+      return;
+    }
+
     let user = getOrCreateUser(
       executor.organization,
       recipient,


### PR DESCRIPTION
## Summary
Fixes the root cause of system contracts (Executor, EligibilityModule) incorrectly appearing as RoleWearers.

## Root Cause
The previous fix used `shouldCreateRoleWearer()` which loads `Organization.executorContract` and `Organization.eligibilityModule`. However, during deployment event processing, these fields may be NULL because `handleOrgDeployed` hasn't finished saving the Organization entity yet.

## Solution
Use direct comparison with `event.address` instead of entity lookups:

- **handleHatsMinted**: If `recipient.equals(contractAddress)`, skip (Executor minting to itself)
- **handleHatClaimed**: If `event.params.wearer.equals(contractAddress)`, skip (EligibilityModule claiming for itself)

This works because `event.address` is always available immediately - no entity lookup needed.

## Changes
- `src/executor.ts`: Added early return when recipient equals executor contract
- `src/eligibility-module.ts`: Added early return when wearer equals eligibility module contract

🤖 Generated with [Claude Code](https://claude.com/claude-code)