### PR TITLE
feat: Store infrastructure proxy addresses in PoaManagerContract

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -1582,6 +1582,11 @@ type PoaManagerContract @entity(immutable: false) {
   beacons: [Beacon!]! @derivedFrom(field: "poaManager")
   beaconUpgrades: [BeaconUpgradeEvent!]! @derivedFrom(field: "poaManager")
   registryUpdates: [RegistryUpdate!]! @derivedFrom(field: "poaManager")
+  # Infrastructure proxy addresses (populated via InfrastructureDeployed event)
+  orgDeployerProxy: Bytes # OrgDeployer proxy contract address
+  orgRegistryProxy: Bytes # OrgRegistry proxy contract address
+  paymasterHubProxy: Bytes # PaymasterHub proxy contract address
+  globalAccountRegistryProxy: Bytes # UniversalAccountRegistry proxy contract address
 }
 
 type Beacon @entity(immutable: false) {

--- a/pop-subgraph/src/poa-manager.ts
+++ b/pop-subgraph/src/poa-manager.ts
@@ -115,6 +115,20 @@ export function handleRegistryUpdated(event: RegistryUpdatedEvent): void {
 }
 
 export function handleInfrastructureDeployed(event: InfrastructureDeployedEvent): void {
+  let contractAddress = event.address;
+
+  // Get or create PoaManagerContract and store infrastructure proxy addresses
+  let poaManager = getOrCreatePoaManager(
+    contractAddress,
+    event.block.timestamp,
+    event.block.number
+  );
+  poaManager.orgDeployerProxy = event.params.orgDeployer;
+  poaManager.orgRegistryProxy = event.params.orgRegistry;
+  poaManager.paymasterHubProxy = event.params.paymasterHub;
+  poaManager.globalAccountRegistryProxy = event.params.globalAccountRegistry;
+  poaManager.save();
+
   // Create data source templates for infrastructure contracts
   // This enables dynamic discovery of infrastructure proxy addresses
   OrgDeployerTemplate.create(event.params.orgDeployer);


### PR DESCRIPTION
## Summary

- Added `orgDeployerProxy`, `orgRegistryProxy`, `paymasterHubProxy`, and `globalAccountRegistryProxy` fields to `PoaManagerContract` entity
- Updated `handleInfrastructureDeployed` to save these proxy addresses when the event is emitted
- These proxy addresses are the actual contracts to interact with (e.g., `OrgDeployer.deployFullOrg()`), distinct from beacon addresses

## Why this is needed

The frontend needs to call the OrgDeployer proxy contract to deploy new organizations. Previously, only beacon addresses were stored, but the proxy addresses (from `InfrastructureDeployed` event) were not persisted anywhere queryable.

## Test plan

- [ ] Run `graph codegen && graph build` to verify schema/mapping changes compile
- [ ] Deploy to testnet subgraph
- [ ] Verify `poaManagerContracts` query returns the new proxy address fields
- [ ] Test frontend deployment flow uses correct OrgDeployer proxy address

🤖 Generated with [Claude Code](https://claude.com/claude-code)