### PR TITLE
fix: Update PoaManager address to correct contract

### DIFF
--- a/pop-subgraph/subgraph.yaml
+++ b/pop-subgraph/subgraph.yaml
@@ -67,7 +67,7 @@ dataSources:
     name: PoaManager
     network: hoodi
     source:
-      address: "0x868680dc2689fa49A8389b0313da15408C8BE340"
+      address: "0x58e4c0f9C905021eDD320d4a5c7a9b70dD6996Fd"
       abi: PoaManager
       startBlock: 1772691
     mapping:


### PR DESCRIPTION
## Summary

- Update PoaManager address from `0x868680dc2689fa49A8389b0313da15408C8BE340` to `0x58e4c0f9C905021eDD320d4a5c7a9b70dD6996Fd`

## Why this is needed

The subgraph was pointing to an old/incorrect PoaManager contract address, which is why:
- Infrastructure proxy addresses (orgDeployerProxy, etc.) were showing as blank
- Beacons were not being indexed correctly

After this fix and redeploying the subgraph, the `InfrastructureDeployed` event from the correct PoaManager will be indexed and infrastructure addresses will be available.

## Test plan

- [ ] Redeploy subgraph
- [ ] Verify `poaManagerContracts` query returns populated proxy addresses
- [ ] Verify beacons are indexed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)