### PR TITLE
Fix IPFS indexing metadata ID mismatch

### DIFF
--- a/pop-subgraph/src/org-registry.ts
+++ b/pop-subgraph/src/org-registry.ts
@@ -115,9 +115,12 @@ export function handleOrgRegistered(event: OrgRegisteredEvent): void {
   org.metadataHash = metadataHash;
 
   // Link to metadata entity (will be populated when IPFS content is indexed)
-  // Use hex string as the metadata ID
-  let metadataId = metadataHash.toHexString();
-  org.metadata = metadataId;
+  // Use CIDv0 format as the metadata ID (must match the ID used in org-metadata.ts)
+  // Skip for zero hash (no metadata)
+  if (!metadataHash.equals(Bytes.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000000"))) {
+    let metadataId = bytes32ToCid(metadataHash);
+    org.metadata = metadataId;
+  }
 
   org.lastUpdatedAt = event.block.timestamp;
   org.save();
@@ -144,8 +147,14 @@ export function handleMetaUpdated(event: MetaUpdatedEvent): void {
     org.metadataHash = newMetadataHash;
 
     // Link to new metadata entity (will be populated when IPFS content is indexed)
-    let metadataId = newMetadataHash.toHexString();
-    org.metadata = metadataId;
+    // Use CIDv0 format as the metadata ID (must match the ID used in org-metadata.ts)
+    // Skip for zero hash (no metadata)
+    if (!newMetadataHash.equals(Bytes.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000000"))) {
+      let metadataId = bytes32ToCid(newMetadataHash);
+      org.metadata = metadataId;
+    } else {
+      org.metadata = null;
+    }
 
     org.lastUpdatedAt = event.block.timestamp;
     org.save();


### PR DESCRIPTION
## Summary

Fixes a critical bug where `Organization.metadata` references used hex format (`0xabcd...`) but the actual `OrgMetadata` entity IDs were in CIDv0 format (`QmXxx...`), causing GraphQL queries to fail when navigating from Organization to metadata.

Now both reference the same CIDv0 format ID, making the relationships work correctly. Also properly handles zero hash case by not setting metadata reference when IPFS content is unavailable.

## Changes

- `org-registry.ts`: Use `bytes32ToCid()` for metadata ID reference instead of hex string
- `org-registry.test.ts`: Updated assertions to verify CIDv0 format matching
- All 79 tests passing