### PR TITLE
Add role name extraction from IPFS metadata

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -1604,6 +1604,7 @@ type OrgMetadataLink @entity(immutable: true) {
 type HatMetadata @entity(immutable: false) {
   id: String! # IPFS hash (CID)
   hat: Hat
+  name: String # Role name fetched from IPFS JSON
   description: String # Fetched from IPFS JSON
   indexedAt: BigInt
 }

--- a/pop-subgraph/src/eligibility-module.ts
+++ b/pop-subgraph/src/eligibility-module.ts
@@ -121,6 +121,14 @@ export function handleHatCreatedWithEligibility(
 
   hat.hatId = hatId;
   hat.parentHatId = event.params.parentHatId;
+  // Calculate level based on parent (0 for top hat, otherwise try to get from parent)
+  let parentHat = Hat.load(contractAddress.toHexString() + "-" + event.params.parentHatId.toString());
+  if (parentHat != null) {
+    hat.level = parentHat.level + 1;
+  } else {
+    // Default to 1 if parent not found (parent might not be indexed yet)
+    hat.level = event.params.parentHatId.equals(BigInt.fromI32(0)) ? 0 : 1;
+  }
   hat.eligibilityModule = contractAddress;
   hat.creator = event.params.creator;
   hat.creatorUsername = getUsernameForAddress(event.params.creator);

--- a/pop-subgraph/tests/eligibility-module-utils.ts
+++ b/pop-subgraph/tests/eligibility-module-utils.ts
@@ -2,7 +2,8 @@ import { newMockEvent } from "matchstick-as";
 import { ethereum, Address, BigInt, Bytes } from "@graphprotocol/graph-ts";
 import {
   HatMetadataUpdated,
-  HatCreatedWithEligibility
+  HatCreatedWithEligibility,
+  DefaultEligibilityUpdated
 } from "../generated/templates/EligibilityModule/EligibilityModule";
 
 export function createHatMetadataUpdatedEvent(
@@ -54,6 +55,31 @@ export function createHatCreatedWithEligibilityEvent(
   );
   event.parameters.push(
     new ethereum.EventParam("mintedCount", ethereum.Value.fromUnsignedBigInt(mintedCount))
+  );
+
+  return event;
+}
+
+export function createDefaultEligibilityUpdatedEvent(
+  hatId: BigInt,
+  eligible: boolean,
+  standing: boolean,
+  admin: Address
+): DefaultEligibilityUpdated {
+  let event = changetype<DefaultEligibilityUpdated>(newMockEvent());
+
+  event.parameters = new Array();
+  event.parameters.push(
+    new ethereum.EventParam("hatId", ethereum.Value.fromUnsignedBigInt(hatId))
+  );
+  event.parameters.push(
+    new ethereum.EventParam("eligible", ethereum.Value.fromBoolean(eligible))
+  );
+  event.parameters.push(
+    new ethereum.EventParam("standing", ethereum.Value.fromBoolean(standing))
+  );
+  event.parameters.push(
+    new ethereum.EventParam("admin", ethereum.Value.fromAddress(admin))
   );
 
   return event;


### PR DESCRIPTION
## Summary
- Add `name` field to HatMetadata entity to store role names from IPFS
- Update `hat-metadata.ts` handler to extract `name` from IPFS JSON and automatically update `Hat.name` when the Hat doesn't already have a name set
- Fix `handleHatCreatedWithEligibility` to properly set the required `level` field (calculates based on parent Hat if available)
- Add comprehensive tests for all new functionality

## Changes

### Schema
- Added `name: String` field to `HatMetadata` entity

### Handlers
- **hat-metadata.ts**: Extracts `name` from IPFS JSON and updates `Hat.name` if not already set
- **eligibility-module.ts**: Fixed `handleHatCreatedWithEligibility` to calculate and set `level` field

### Tests (14 new tests)
- `hat-metadata.test.ts`:
  - Parses name from IPFS JSON
  - Parses both name and description
  - Updates Hat.name from IPFS when Hat has no name
  - Does NOT update Hat.name when Hat already has a name
  - Handles empty/null/non-string name values gracefully
  - Handles missing Hat entity gracefully

- `eligibility-module.test.ts`:
  - DefaultEligibilityUpdated creates Hat when hat doesn't exist
  - DefaultEligibilityUpdated creates Role and links Hat to Role
  - DefaultEligibilityUpdated updates existing Hat without duplicating Role
  - DefaultEligibilityUpdated does not duplicate Role link on existing Hat
  - HatCreatedWithEligibility creates Hat and links to Role

## Test plan
- [x] `npm run build` succeeds
- [x] All 177 tests pass (`npm run test`)
- [ ] Deploy to testnet and verify role names appear in queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)