### PR TITLE
Add isUserRole field to filter system roles from user roles

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -557,6 +557,7 @@ type Role @entity(immutable: false) {
   image: String # Role image URL
   metadataCID: Bytes # IPFS CID for extended metadata
   canVote: Boolean # Whether this role can vote
+  isUserRole: Boolean # True for user-defined roles (in roleHatIds), false for system hats (TopHat, AdminHat)
 
   # Timestamps
   createdAt: BigInt!


### PR DESCRIPTION
## Summary
- Add `isUserRole` Boolean field to Role entity to distinguish user-defined roles from system hats
- System hats (TopHat, EligibilityAdminHat) are no longer created as Role entities OR have isUserRole = false
- User-defined roles (from roleHatIds) have isUserRole = true
- Frontend queries can filter with `roles(where: { isUserRole: true })` to only show user roles

## Changes
- **schema.graphql**: Add `isUserRole: Boolean` field to Role entity
- **src/org-deployer.ts**: 
  - Remove Role creation for topHatId (system hat)
  - Set isUserRole = true for roleHatIds
  - handleRolesCreated sets isUserRole = true
- **src/utils.ts**:
  - Update getOrCreateRole to accept isUserRole parameters
  - Update linkHatToRole to determine isUserRole from org.roleHatIds
- **tests/org-deployer.test.ts**:
  - Add 2 new tests for isUserRole filtering
  - Update existing tests with isUserRole assertions

## Why
Users were seeing "Role 1", "Role 2" phantom roles on the org-structure page caused by system hats (TopHat, EligibilityAdminHat) being indexed as Role entities. This PR moves the filtering logic from the frontend to the subgraph where it belongs.

## Test plan
- [x] All 183 tests pass
- [ ] Deploy to testnet and verify only user roles appear in queries
- [ ] Verify org-structure page no longer shows phantom roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)