### PR TITLE
Update PoaManager contract address and start block

### DIFF
--- a/pop-subgraph/subgraph.yaml
+++ b/pop-subgraph/subgraph.yaml
@@ -67,9 +67,9 @@ dataSources:
     name: PoaManager
     network: hoodi
     source:
-      address: "0xd2b5f225a0e80f2B7916923D4f5F4EF6cc777CB6"
+      address: "0x116bE92C998F0447D2C54DC1Bb8cE4aaDf06eA1f"
       abi: PoaManager
-      startBlock: 1783655
+      startBlock: 1785792
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9


### PR DESCRIPTION
## Summary
Updated PoaManager contract configuration with new address and start block for proper event indexing on the hoodi network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)