### PR TITLE
Fix entity overwrite bug and add CLAUDE.md guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+# POP Subgraph
+
+The Graph Protocol subgraph for the Perpetual Organization Protocol (POP) on the hoodi network. POP enables fully worker and community owned DAOs—a step toward fairer, more democratic economic systems where the people who create value also control it.
+
+## Commands
+
+All commands run from `pop-subgraph/` directory:
+
+```bash
+npm run codegen    # Generate types from schema.graphql
+npm run build      # Build WebAssembly mappings
+npm run test       # Run Matchstick tests
+subgraph-lint      # Lint the subgraph
+```
+
+## Before Creating a PR
+
+Run these commands in order and ensure they all pass:
+
+```bash
+cd pop-subgraph
+npm run codegen
+npm run build
+npm run test
+subgraph-lint
+```
+
+## Structure
+
+- `schema.graphql` - GraphQL entity definitions
+- `subgraph.yaml` - Data sources, templates, and event handlers
+- `src/` - Event handler implementations (AssemblyScript)
+- `abis/` - Contract ABIs
+- `tests/` - Matchstick unit tests
+
+## Key Patterns
+
+- **Data sources**: PoaManager and GovernanceFactory are hardcoded; other contracts use dynamic templates
+- **Entity IDs**: Use format `contractAddress-entitySpecificId` for uniqueness
+- **IPFS metadata**: OrgMetadata and HatMetadata templates handle off-chain data
+- **Tests**: Each handler has a corresponding `*-utils.ts` file for test fixtures

--- a/pop-subgraph/src/eligibility-module.ts
+++ b/pop-subgraph/src/eligibility-module.ts
@@ -478,14 +478,13 @@ export function handleHatClaimed(event: HatClaimedEvent): void {
         event
       );
 
-      // Record the hat change on the user
-      recordUserHatChange(user, hatId, true, event);
-
-      // Update join method if this is their first hat
+      // Update join method if this is their first hat (before recordUserHatChange saves)
       if (user.joinMethod == null) {
         user.joinMethod = "HatClaim";
-        user.save();
       }
+
+      // Record the hat change on the user (this will save the user)
+      recordUserHatChange(user, hatId, true, event);
     }
   }
 


### PR DESCRIPTION
## Summary
- Fixed entity overwrite bug in `handleHatClaimed` where user modifications were lost when saving
- Added CLAUDE.md with POP subgraph setup and pre-PR checklist

## Changes
Move `joinMethod` assignment before `recordUserHatChange` to ensure both user entity modifications (joinMethod and currentHatIds) are persisted together. Previously, `recordUserHatChange` saved the user, but subsequent `user.save()` overwrote it with stale in-memory data, losing the currentHatIds update.

## Testing
- All 184 Matchstick tests pass
- Build succeeds (npm run codegen && npm run build)
- subgraph-lint passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)