### PR TITLE
Filter system contracts from User entity creation

### DIFF
--- a/pop-subgraph/src/direct-democracy-voting.ts
+++ b/pop-subgraph/src/direct-democracy-voting.ts
@@ -320,9 +320,11 @@ export function handleVoteCast(event: VoteCast): void {
       event.block.timestamp,
       event.block.number
     );
-    vote.voterUser = user.id;
-    user.totalVotes = user.totalVotes.plus(BigInt.fromI32(1));
-    user.save();
+    if (user) {
+      vote.voterUser = user.id;
+      user.totalVotes = user.totalVotes.plus(BigInt.fromI32(1));
+      user.save();
+    }
   }
 
   // Convert uint8[] arrays to Int arrays for optionIndexes and optionWeights

--- a/pop-subgraph/src/education-hub.ts
+++ b/pop-subgraph/src/education-hub.ts
@@ -80,9 +80,11 @@ export function handleModuleCompleted(event: ModuleCompletedEvent): void {
       event.block.timestamp,
       event.block.number
     );
-    completion.learnerUser = user.id;
-    user.totalModulesCompleted = user.totalModulesCompleted.plus(BigInt.fromI32(1));
-    user.save();
+    if (user) {
+      completion.learnerUser = user.id;
+      user.totalModulesCompleted = user.totalModulesCompleted.plus(BigInt.fromI32(1));
+      user.save();
+    }
   }
 
   completion.completedAt = event.block.timestamp;

--- a/pop-subgraph/src/eligibility-module.ts
+++ b/pop-subgraph/src/eligibility-module.ts
@@ -142,7 +142,9 @@ export function handleHatCreatedWithEligibility(
       event.block.timestamp,
       event.block.number
     );
-    hat.creatorUser = user.id;
+    if (user) {
+      hat.creatorUser = user.id;
+    }
   }
 
   hat.defaultEligible = event.params.defaultEligible;
@@ -195,7 +197,9 @@ export function handleWearerEligibilityUpdated(
       event.block.timestamp,
       event.block.number
     );
-    wearerEligibility.wearerUser = wearerUser.id;
+    if (wearerUser) {
+      wearerEligibility.wearerUser = wearerUser.id;
+    }
 
     // Link admin
     let adminUser = getOrCreateUser(
@@ -204,7 +208,9 @@ export function handleWearerEligibilityUpdated(
       event.block.timestamp,
       event.block.number
     );
-    wearerEligibility.adminUser = adminUser.id;
+    if (adminUser) {
+      wearerEligibility.adminUser = adminUser.id;
+    }
   }
 
   wearerEligibility.updatedAt = event.block.timestamp;
@@ -256,7 +262,9 @@ export function handleBulkWearerEligibilityUpdated(
         event.block.timestamp,
         event.block.number
       );
-      wearerEligibility.wearerUser = wearerUser.id;
+      if (wearerUser) {
+        wearerEligibility.wearerUser = wearerUser.id;
+      }
 
       // Link admin
       let adminUser = getOrCreateUser(
@@ -265,7 +273,9 @@ export function handleBulkWearerEligibilityUpdated(
         event.block.timestamp,
         event.block.number
       );
-      wearerEligibility.adminUser = adminUser.id;
+      if (adminUser) {
+        wearerEligibility.adminUser = adminUser.id;
+      }
     }
 
     wearerEligibility.updatedAt = event.block.timestamp;
@@ -307,7 +317,9 @@ export function handleDefaultEligibilityUpdated(
         event.block.timestamp,
         event.block.number
       );
-      hat.creatorUser = user.id;
+      if (user) {
+        hat.creatorUser = user.id;
+      }
     }
 
     hat.defaultEligible = event.params.eligible;
@@ -393,7 +405,9 @@ export function handleVouched(event: VouchedEvent): void {
       event.block.timestamp,
       event.block.number
     );
-    vouch.wearerUser = wearerUser.id;
+    if (wearerUser) {
+      vouch.wearerUser = wearerUser.id;
+    }
 
     // Link voucher
     let voucherUser = getOrCreateUser(
@@ -402,7 +416,9 @@ export function handleVouched(event: VouchedEvent): void {
       event.block.timestamp,
       event.block.number
     );
-    vouch.voucherUser = voucherUser.id;
+    if (voucherUser) {
+      vouch.voucherUser = voucherUser.id;
+    }
   }
 
   vouch.createdAt = event.block.timestamp;
@@ -466,25 +482,27 @@ export function handleHatClaimed(event: HatClaimedEvent): void {
       event.block.timestamp,
       event.block.number
     );
-    claim.wearerUser = user.id;
+    if (user) {
+      claim.wearerUser = user.id;
 
-    // Only create RoleWearer for user-facing hats to non-system addresses
-    if (shouldCreateRoleWearer(eligibilityModule.organization, hatId, event.params.wearer)) {
-      // Create RoleWearer entity
-      getOrCreateRoleWearer(
-        eligibilityModule.organization,
-        hatId,
-        event.params.wearer,
-        event
-      );
+      // Only create RoleWearer for user-facing hats to non-system addresses
+      if (shouldCreateRoleWearer(eligibilityModule.organization, hatId, event.params.wearer)) {
+        // Create RoleWearer entity
+        getOrCreateRoleWearer(
+          eligibilityModule.organization,
+          hatId,
+          event.params.wearer,
+          event
+        );
 
-      // Update join method if this is their first hat (before recordUserHatChange saves)
-      if (user.joinMethod == null) {
-        user.joinMethod = "HatClaim";
+        // Update join method if this is their first hat (before recordUserHatChange saves)
+        if (user.joinMethod == null) {
+          user.joinMethod = "HatClaim";
+        }
+
+        // Record the hat change on the user (this will save the user)
+        recordUserHatChange(user, hatId, true, event);
       }
-
-      // Record the hat change on the user (this will save the user)
-      recordUserHatChange(user, hatId, true, event);
     }
   }
 
@@ -591,7 +609,9 @@ export function handleVouchingRateLimitExceeded(
       event.block.timestamp,
       event.block.number
     );
-    restriction.userUser = user.id;
+    if (user) {
+      restriction.userUser = user.id;
+    }
   }
 
   restriction.save();
@@ -620,7 +640,9 @@ export function handleNewUserVouchingRestricted(
       event.block.timestamp,
       event.block.number
     );
-    restriction.userUser = user.id;
+    if (user) {
+      restriction.userUser = user.id;
+    }
   }
 
   restriction.save();

--- a/pop-subgraph/src/executor.ts
+++ b/pop-subgraph/src/executor.ts
@@ -211,24 +211,26 @@ export function handleHatsMinted(event: HatsMintedEvent): void {
       event.block.timestamp,
       event.block.number
     );
-    mint.recipientUser = user.id;
+    if (user) {
+      mint.recipientUser = user.id;
 
-    // Create RoleWearers for each minted hat (only for user-facing hats to non-system addresses)
-    let hatIds = event.params.hatIds;
-    for (let i = 0; i < hatIds.length; i++) {
-      let hatId = hatIds[i];
-      // Only create RoleWearer for eligible combinations (not system contracts, not system hats)
-      if (shouldCreateRoleWearer(executor.organization, hatId, recipient)) {
-        getOrCreateRoleWearer(
-          executor.organization,
-          hatId,
-          recipient,
-          event
-        );
-        recordUserHatChange(user, hatId, true, event);
+      // Create RoleWearers for each minted hat (only for user-facing hats to non-system addresses)
+      let hatIds = event.params.hatIds;
+      for (let i = 0; i < hatIds.length; i++) {
+        let hatId = hatIds[i];
+        // Only create RoleWearer for eligible combinations (not system contracts, not system hats)
+        if (shouldCreateRoleWearer(executor.organization, hatId, recipient)) {
+          getOrCreateRoleWearer(
+            executor.organization,
+            hatId,
+            recipient,
+            event
+          );
+          recordUserHatChange(user, hatId, true, event);
+        }
       }
+      user.save();
     }
-    user.save();
   }
 
   mint.save();

--- a/pop-subgraph/src/hybrid-voting.ts
+++ b/pop-subgraph/src/hybrid-voting.ts
@@ -240,7 +240,9 @@ export function handleNewProposal(event: NewProposal): void {
       event.block.timestamp,
       event.block.number
     );
-    proposal.creatorUser = user.id;
+    if (user) {
+      proposal.creatorUser = user.id;
+    }
   }
 
   proposal.title = event.params.title.toString();
@@ -283,7 +285,9 @@ export function handleNewHatProposal(event: NewHatProposal): void {
       event.block.timestamp,
       event.block.number
     );
-    proposal.creatorUser = user.id;
+    if (user) {
+      proposal.creatorUser = user.id;
+    }
   }
 
   proposal.title = event.params.title.toString();
@@ -326,9 +330,11 @@ export function handleVoteCast(event: VoteCast): void {
       event.block.timestamp,
       event.block.number
     );
-    vote.voterUser = user.id;
-    user.totalVotes = user.totalVotes.plus(BigInt.fromI32(1));
-    user.save();
+    if (user) {
+      vote.voterUser = user.id;
+      user.totalVotes = user.totalVotes.plus(BigInt.fromI32(1));
+      user.save();
+    }
   }
 
   // Convert uint8[] arrays to Int arrays for optionIndexes and optionWeights

--- a/pop-subgraph/src/participation-token.ts
+++ b/pop-subgraph/src/participation-token.ts
@@ -70,8 +70,10 @@ export function handleTransfer(event: TransferEvent): void {
         event.block.timestamp,
         event.block.number
       );
-      fromUser.participationTokenBalance = fromUser.participationTokenBalance.minus(amount);
-      fromUser.save();
+      if (fromUser) {
+        fromUser.participationTokenBalance = fromUser.participationTokenBalance.minus(amount);
+        fromUser.save();
+      }
     }
   } else {
     // This is a mint - increase total supply
@@ -106,8 +108,10 @@ export function handleTransfer(event: TransferEvent): void {
         event.block.timestamp,
         event.block.number
       );
-      toUser.participationTokenBalance = toUser.participationTokenBalance.plus(amount);
-      toUser.save();
+      if (toUser) {
+        toUser.participationTokenBalance = toUser.participationTokenBalance.plus(amount);
+        toUser.save();
+      }
     }
   } else {
     // This is a burn - decrease total supply

--- a/pop-subgraph/src/payment-manager.ts
+++ b/pop-subgraph/src/payment-manager.ts
@@ -88,9 +88,11 @@ export function handleDistributionClaimed(event: DistributionClaimedEvent): void
       event.block.timestamp,
       event.block.number
     );
-    claim.claimerUser = user.id;
-    user.totalClaimsAmount = user.totalClaimsAmount.plus(amount);
-    user.save();
+    if (user) {
+      claim.claimerUser = user.id;
+      user.totalClaimsAmount = user.totalClaimsAmount.plus(amount);
+      user.save();
+    }
   }
 
   claim.amount = amount;
@@ -140,9 +142,11 @@ export function handlePaymentReceived(event: PaymentReceivedEvent): void {
       event.block.timestamp,
       event.block.number
     );
-    payment.payerUser = user.id;
-    user.totalPaymentsAmount = user.totalPaymentsAmount.plus(event.params.amount);
-    user.save();
+    if (user) {
+      payment.payerUser = user.id;
+      user.totalPaymentsAmount = user.totalPaymentsAmount.plus(event.params.amount);
+      user.save();
+    }
   }
 
   payment.amount = event.params.amount;

--- a/pop-subgraph/src/quick-join.ts
+++ b/pop-subgraph/src/quick-join.ts
@@ -63,19 +63,21 @@ export function handleQuickJoined(event: QuickJoinedEvent): void {
       event.block.number
     );
 
-    let hatIds = event.params.hatIds;
-    for (let i = 0; i < hatIds.length; i++) {
-      // Only create RoleWearer for eligible combinations
-      if (shouldCreateRoleWearer(contract.organization, hatIds[i], event.params.user)) {
-        getOrCreateRoleWearer(contract.organization, hatIds[i], event.params.user, event);
-        recordUserHatChange(user, hatIds[i], true, event);
+    if (user) {
+      let hatIds = event.params.hatIds;
+      for (let i = 0; i < hatIds.length; i++) {
+        // Only create RoleWearer for eligible combinations
+        if (shouldCreateRoleWearer(contract.organization, hatIds[i], event.params.user)) {
+          getOrCreateRoleWearer(contract.organization, hatIds[i], event.params.user, event);
+          recordUserHatChange(user, hatIds[i], true, event);
+        }
       }
-    }
 
-    // Update join method
-    if (user.joinMethod == null) {
-      user.joinMethod = "QuickJoin";
-      user.save();
+      // Update join method
+      if (user.joinMethod == null) {
+        user.joinMethod = "QuickJoin";
+        user.save();
+      }
     }
   }
 }
@@ -107,19 +109,21 @@ export function handleQuickJoinedByMaster(event: QuickJoinedByMasterEvent): void
       event.block.number
     );
 
-    let hatIds = event.params.hatIds;
-    for (let i = 0; i < hatIds.length; i++) {
-      // Only create RoleWearer for eligible combinations
-      if (shouldCreateRoleWearer(contract.organization, hatIds[i], event.params.user)) {
-        getOrCreateRoleWearer(contract.organization, hatIds[i], event.params.user, event);
-        recordUserHatChange(user, hatIds[i], true, event);
+    if (user) {
+      let hatIds = event.params.hatIds;
+      for (let i = 0; i < hatIds.length; i++) {
+        // Only create RoleWearer for eligible combinations
+        if (shouldCreateRoleWearer(contract.organization, hatIds[i], event.params.user)) {
+          getOrCreateRoleWearer(contract.organization, hatIds[i], event.params.user, event);
+          recordUserHatChange(user, hatIds[i], true, event);
+        }
       }
-    }
 
-    // Update join method
-    if (user.joinMethod == null) {
-      user.joinMethod = "QuickJoin";
-      user.save();
+      // Update join method
+      if (user.joinMethod == null) {
+        user.joinMethod = "QuickJoin";
+        user.save();
+      }
     }
   }
 }
@@ -293,18 +297,20 @@ export function handleQuickJoinedWithPasskey(event: QuickJoinedWithPasskeyEvent)
     event.block.number
   );
 
-  let hatIds = event.params.hatIds;
-  for (let i = 0; i < hatIds.length; i++) {
-    if (shouldCreateRoleWearer(contract.organization, hatIds[i], event.params.account)) {
-      getOrCreateRoleWearer(contract.organization, hatIds[i], event.params.account, event);
-      recordUserHatChange(user, hatIds[i], true, event);
+  if (user) {
+    let hatIds = event.params.hatIds;
+    for (let i = 0; i < hatIds.length; i++) {
+      if (shouldCreateRoleWearer(contract.organization, hatIds[i], event.params.account)) {
+        getOrCreateRoleWearer(contract.organization, hatIds[i], event.params.account, event);
+        recordUserHatChange(user, hatIds[i], true, event);
+      }
     }
-  }
 
-  // Update join method
-  if (user.joinMethod == null) {
-    user.joinMethod = "QuickJoinWithPasskey";
-    user.save();
+    // Update join method
+    if (user.joinMethod == null) {
+      user.joinMethod = "QuickJoinWithPasskey";
+      user.save();
+    }
   }
 }
 
@@ -342,17 +348,19 @@ export function handleQuickJoinedWithPasskeyByMaster(event: QuickJoinedWithPassk
     event.block.number
   );
 
-  let hatIds = event.params.hatIds;
-  for (let i = 0; i < hatIds.length; i++) {
-    if (shouldCreateRoleWearer(contract.organization, hatIds[i], event.params.account)) {
-      getOrCreateRoleWearer(contract.organization, hatIds[i], event.params.account, event);
-      recordUserHatChange(user, hatIds[i], true, event);
+  if (user) {
+    let hatIds = event.params.hatIds;
+    for (let i = 0; i < hatIds.length; i++) {
+      if (shouldCreateRoleWearer(contract.organization, hatIds[i], event.params.account)) {
+        getOrCreateRoleWearer(contract.organization, hatIds[i], event.params.account, event);
+        recordUserHatChange(user, hatIds[i], true, event);
+      }
     }
-  }
 
-  // Update join method
-  if (user.joinMethod == null) {
-    user.joinMethod = "QuickJoinWithPasskey";
-    user.save();
+    // Update join method
+    if (user.joinMethod == null) {
+      user.joinMethod = "QuickJoinWithPasskey";
+      user.save();
+    }
   }
 }

--- a/pop-subgraph/src/task-manager.ts
+++ b/pop-subgraph/src/task-manager.ts
@@ -111,7 +111,9 @@ export function handleTaskAssigned(event: TaskAssigned): void {
         event.block.timestamp,
         event.block.number
       );
-      task.assigneeUser = user.id;
+      if (user) {
+        task.assigneeUser = user.id;
+      }
     }
 
     task.assignee = event.params.assignee;
@@ -168,11 +170,13 @@ export function handleTaskCompleted(event: TaskCompleted): void {
         event.block.timestamp,
         event.block.number
       );
-      task.completerUser = user.id;
+      if (user) {
+        task.completerUser = user.id;
 
-      // Increment totalTasksCompleted
-      user.totalTasksCompleted = user.totalTasksCompleted.plus(BigInt.fromI32(1));
-      user.save();
+        // Increment totalTasksCompleted
+        user.totalTasksCompleted = user.totalTasksCompleted.plus(BigInt.fromI32(1));
+        user.save();
+      }
     }
 
     // Set assignee to completer if not already set
@@ -205,11 +209,13 @@ export function handleTaskCancelled(event: TaskCancelled): void {
         event.block.timestamp,
         event.block.number
       );
-      task.cancellerUser = user.id;
+      if (user) {
+        task.cancellerUser = user.id;
 
-      // Increment totalTasksCancelled
-      user.totalTasksCancelled = user.totalTasksCancelled.plus(BigInt.fromI32(1));
-      user.save();
+        // Increment totalTasksCancelled
+        user.totalTasksCancelled = user.totalTasksCancelled.plus(BigInt.fromI32(1));
+        user.save();
+      }
     }
 
     task.canceller = event.params.canceller;
@@ -259,7 +265,9 @@ export function handleTaskApplicationSubmitted(event: TaskApplicationSubmitted):
       event.block.timestamp,
       event.block.number
     );
-    application.applicantUser = user.id;
+    if (user) {
+      application.applicantUser = user.id;
+    }
   }
 
   application.applicationHash = event.params.applicationHash;
@@ -287,7 +295,9 @@ export function handleTaskApplicationApproved(event: TaskApplicationApproved): v
         event.block.timestamp,
         event.block.number
       );
-      application.approverUser = user.id;
+      if (user) {
+        application.approverUser = user.id;
+      }
     }
 
     application.approved = true;
@@ -353,7 +363,9 @@ export function handleProjectManagerUpdated(event: ProjectManagerUpdated): void 
         event.block.timestamp,
         event.block.number
       );
-      manager.managerUser = user.id;
+      if (user) {
+        manager.managerUser = user.id;
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Prevents Executor and EligibilityModule contract addresses from being indexed as User entities
- Fixes inflated member counts in organizations where system contracts were incorrectly counted as members

## Changes
- Modified `getOrCreateUser()` in `utils.ts` to check `isSystemContract()` and return `null` for system contracts
- Updated `getOrCreateRoleWearer()` to return `null` if user creation fails (system contract case)
- Added null checks in all 10 handler files that call `getOrCreateUser()`:
  - eligibility-module.ts (8 calls)
  - executor.ts (1 call)
  - quick-join.ts (4 calls)
  - hybrid-voting.ts (3 calls)
  - direct-democracy-voting.ts (1 call)
  - education-hub.ts (1 call)
  - participation-token.ts (2 calls)
  - payment-manager.ts (2 calls)
  - task-manager.ts (6 calls)
  - utils.ts (1 call in getOrCreateRoleWearer)

## Technical Details
The `isSystemContract()` utility already identifies Executor and EligibilityModule addresses. This change leverages that existing infrastructure to filter at the User creation level, rather than just at RoleWearer creation.

## Test plan
- [ ] Deploy updated subgraph to test environment
- [ ] Verify system contracts no longer appear in `org.users` array
- [ ] Verify `poMembers` count reflects only real users
- [ ] Ensure real users still work: voting, tasks, eligibility functions normally
- [ ] Test edge cases: new org deployment, hat minting, eligibility updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)