### PR TITLE
Fix: Don't create User entities for hat creators during deployment

### DIFF
--- a/pop-subgraph/src/eligibility-module.ts
+++ b/pop-subgraph/src/eligibility-module.ts
@@ -133,19 +133,10 @@ export function handleHatCreatedWithEligibility(
   hat.creator = event.params.creator;
   hat.creatorUsername = getUsernameForAddress(event.params.creator);
 
-  // Link to User entity
+  // Note: We intentionally do NOT create a User entity for the creator here.
+  // During deployment, hats are often created by helper contracts (HatsTreeSetup, etc.)
+  // which are not real users. The creator address is still stored in hat.creator.
   let eligibilityModule = EligibilityModuleContract.load(contractAddress);
-  if (eligibilityModule) {
-    let user = getOrCreateUser(
-      eligibilityModule.organization,
-      event.params.creator,
-      event.block.timestamp,
-      event.block.number
-    );
-    if (user) {
-      hat.creatorUser = user.id;
-    }
-  }
 
   hat.defaultEligible = event.params.defaultEligible;
   hat.defaultStanding = event.params.defaultStanding;
@@ -308,19 +299,9 @@ export function handleDefaultEligibilityUpdated(
     hat.creator = event.params.admin; // Use admin as creator
     hat.creatorUsername = getUsernameForAddress(event.params.admin);
 
-    // Link to User entity if EligibilityModuleContract exists
-    let eligibilityModule = EligibilityModuleContract.load(contractAddress);
-    if (eligibilityModule) {
-      let user = getOrCreateUser(
-        eligibilityModule.organization,
-        event.params.admin,
-        event.block.timestamp,
-        event.block.number
-      );
-      if (user) {
-        hat.creatorUser = user.id;
-      }
-    }
+    // Note: We intentionally do NOT create a User entity for the admin here.
+    // During deployment, hats are often created/configured by helper contracts
+    // which are not real users. The admin address is stored in hat.creator.
 
     hat.defaultEligible = event.params.eligible;
     hat.defaultStanding = event.params.standing;


### PR DESCRIPTION
## Summary
- Fixes inflated member count caused by hat creators (HatsTreeSetup, deployment helpers) being indexed as users
- During org deployment, hats are created by helper contracts - these should NOT be counted as members
- Removes `getOrCreateUser()` calls for creators in `handleHatCreatedWithEligibility` and `handleDefaultEligibilityUpdated`

## Root Cause
For org `0x24e5ff10c23324037a282d47a5cff62994f33558e245d58aba3d3a5c95315163` on Hoodi testnet, address `0xac4bfed61b39d158254802ae7dd409280ee4aa98` was being indexed as a user because it was the `creator` of all hats (likely a HatsTreeSetup contract).

This address wasn't filtered by `isSystemContract()` (which only checks Executor and EligibilityModule), so a User entity was created.

## Test plan
- [ ] Deploy to test environment
- [ ] Verify org shows 1 user instead of 2
- [ ] Confirm hat.creator field still stores the address correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)