### PR TITLE
Fix: Don't create User entities for admin/wearer in eligibility updates

### DIFF
--- a/pop-subgraph/src/eligibility-module.ts
+++ b/pop-subgraph/src/eligibility-module.ts
@@ -178,31 +178,10 @@ export function handleWearerEligibilityUpdated(
   wearerEligibility.adminUsername = getUsernameForAddress(event.params.admin);
   wearerEligibility.wearerUsername = getUsernameForAddress(wearer);
 
-  // Link to User entities
-  let eligibilityModule = EligibilityModuleContract.load(contractAddress);
-  if (eligibilityModule) {
-    // Link wearer
-    let wearerUser = getOrCreateUser(
-      eligibilityModule.organization,
-      wearer,
-      event.block.timestamp,
-      event.block.number
-    );
-    if (wearerUser) {
-      wearerEligibility.wearerUser = wearerUser.id;
-    }
-
-    // Link admin
-    let adminUser = getOrCreateUser(
-      eligibilityModule.organization,
-      event.params.admin,
-      event.block.timestamp,
-      event.block.number
-    );
-    if (adminUser) {
-      wearerEligibility.adminUser = adminUser.id;
-    }
-  }
+  // Note: We intentionally do NOT create User entities for admin or wearer here.
+  // Admins and wearers during deployment are often helper contracts, not real org members.
+  // The addresses are still stored in wearerEligibility.admin and wearer fields for reference.
+  // Real users get their User entities when they claim hats (HatClaimed event).
 
   wearerEligibility.updatedAt = event.block.timestamp;
   wearerEligibility.updatedAtBlock = event.block.number;
@@ -220,9 +199,6 @@ export function handleBulkWearerEligibilityUpdated(
   let eligible = event.params.eligible;
   let standing = event.params.standing;
   let admin = event.params.admin;
-
-  // Get organization for User linking
-  let eligibilityModule = EligibilityModuleContract.load(contractAddress);
 
   for (let i = 0; i < wearers.length; i++) {
     let wearer = wearers[i];
@@ -244,30 +220,10 @@ export function handleBulkWearerEligibilityUpdated(
     wearerEligibility.adminUsername = getUsernameForAddress(admin);
     wearerEligibility.wearerUsername = getUsernameForAddress(wearer);
 
-    // Link to User entities
-    if (eligibilityModule) {
-      // Link wearer
-      let wearerUser = getOrCreateUser(
-        eligibilityModule.organization,
-        wearer,
-        event.block.timestamp,
-        event.block.number
-      );
-      if (wearerUser) {
-        wearerEligibility.wearerUser = wearerUser.id;
-      }
-
-      // Link admin
-      let adminUser = getOrCreateUser(
-        eligibilityModule.organization,
-        admin,
-        event.block.timestamp,
-        event.block.number
-      );
-      if (adminUser) {
-        wearerEligibility.adminUser = adminUser.id;
-      }
-    }
+    // Note: We intentionally do NOT create User entities for admin or wearer here.
+    // Admins and wearers during deployment are often helper contracts, not real org members.
+    // The addresses are still stored in wearerEligibility.admin and wearer fields for reference.
+    // Real users get their User entities when they claim hats (HatClaimed event).
 
     wearerEligibility.updatedAt = event.block.timestamp;
     wearerEligibility.updatedAtBlock = event.block.number;


### PR DESCRIPTION
## Summary
Fixes inflated member count caused by `handleWearerEligibilityUpdated` and `handleBulkWearerEligibilityUpdated` creating User entities for admin addresses.

## Root Cause
For org `0x24e5ff10...` on Hoodi testnet, address `0xac4bfed61b39d158254802ae7dd409280ee4aa98` was being indexed as a user because:

1. It appeared as the `admin` in multiple `WearerEligibilityUpdated` events during deployment
2. `handleWearerEligibilityUpdated` was calling `getOrCreateUser()` for both wearer AND admin
3. This address (likely HatsTreeSetup) isn't in `isSystemContract()` check, so a User entity was created

Query showing the problem:
```graphql
wearerEligibilities(where: { admin: "0xac4bfed61b39d158254802ae7dd409280ee4aa98" })
```
Returns 6 entries where this helper contract set eligibility.

## Changes
- Remove `getOrCreateUser()` calls for admin in `handleWearerEligibilityUpdated`
- Remove `getOrCreateUser()` calls for admin in `handleBulkWearerEligibilityUpdated`
- Remove `getOrCreateUser()` calls for wearer in both handlers

Real users get their User entities when they claim hats (`HatClaimed` event with `joinMethod: "HatClaim"`), not when their eligibility is set.

## Test plan
- [ ] Deploy to test environment with fresh index
- [ ] Verify org shows 1 user instead of 2
- [ ] Confirm WearerEligibility still has admin/wearer addresses for reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)