### PR TITLE
Fix account creation: lower PoaManager startBlock

### DIFF
--- a/pop-subgraph/subgraph.yaml
+++ b/pop-subgraph/subgraph.yaml
@@ -69,7 +69,7 @@ dataSources:
     source:
       address: "0x91ADe310CA1d78d8EE68F9619674b3A2a906148b"
       abi: PoaManager
-      startBlock: 2078486
+      startBlock: 2078000
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9


### PR DESCRIPTION
## Summary
The PoaManager startBlock was set too late (2078486), preventing the InfrastructureDeployed event from being captured. This caused the UniversalAccountRegistry template to never be created, resulting in all UserRegistered and UsernameChanged events being missed during indexing.

Lowered startBlock to 2078000 to ensure the event is properly captured and accounts are created during reindexing.

## Test plan
- Verified codegen, build, and all 184 tests pass
- Subgraph linting shows no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)