### PR TITLE
Fix task submission overwriting original metadata

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -255,7 +255,8 @@ type Task @entity(immutable: false) {
   bountyPayout: BigInt!
   requiresApplication: Boolean!
   title: String! # task title
-  metadataHash: Bytes! # task metadata hash
+  metadataHash: Bytes! # task metadata hash (description, difficulty, estHours)
+  submissionHash: Bytes # submission metadata hash (set when task is submitted)
   assignee: Bytes
   assigneeUsername: String
   assigneeUser: User

--- a/pop-subgraph/src/task-manager.ts
+++ b/pop-subgraph/src/task-manager.ts
@@ -148,8 +148,8 @@ export function handleTaskSubmitted(event: TaskSubmitted): void {
   if (task) {
     task.status = "Submitted";
     task.submittedAt = event.block.timestamp;
-    // submissionHash is now bytes32 - store in metadataHash
-    task.metadataHash = event.params.submissionHash;
+    // Store submission hash separately - don't overwrite original task metadata
+    task.submissionHash = event.params.submissionHash;
     task.save();
   }
 }


### PR DESCRIPTION
## Summary
- Fixed critical bug where `handleTaskSubmitted` was overwriting `task.metadataHash` with the submission hash
- Added new `submissionHash` field to Task entity to store submission data separately
- Original task metadata (description, difficulty, estHours) is now preserved when task is submitted

## Problem
When a task was submitted, the original task metadata was being destroyed because the handler was overwriting `metadataHash` with the submission hash. This caused the frontend to lose access to task descriptions.

## Test plan
- [ ] Deploy updated subgraph
- [ ] Create a task with description/difficulty/estHours
- [ ] Submit the task
- [ ] Verify original task metadata is still accessible via metadataHash
- [ ] Verify submission data is accessible via submissionHash

🤖 Generated with [Claude Code](https://claude.com/claude-code)