### PR TITLE
Fix estHours parsing for decimal values

### DIFF
--- a/pop-subgraph/src/task-metadata.ts
+++ b/pop-subgraph/src/task-metadata.ts
@@ -85,11 +85,13 @@ export function handleTaskMetadata(content: Bytes): void {
       metadata.difficulty = difficultyValue.toString();
     }
 
-    // Parse estHours (estimated hours)
+    // Parse estHours (estimated hours) - can be decimal like 0.5
     let estHoursValue = jsonObject.get("estHours");
     if (estHoursValue != null && !estHoursValue.isNull()) {
       if (estHoursValue.kind == JSONValueKind.NUMBER) {
-        metadata.estimatedHours = estHoursValue.toI64() as i32;
+        // Use toF64() to handle decimal values, then round to nearest integer
+        let floatValue = estHoursValue.toF64();
+        metadata.estimatedHours = i32(Math.round(floatValue));
       }
     }
 


### PR DESCRIPTION
## Summary

- Fix task metadata indexing error when `estHours` is a decimal value like `0.5`
- Use `toF64()` instead of `toI64()` to handle decimal values, then round to nearest integer

## Issue

```
JSON `0.5` cannot be parsed as i64 in handler `handleTaskMetadata`
```

The `toI64()` method fails on non-integer JSON numbers. Changed to `toF64()` which handles decimals, then `Math.round()` to convert to integer.

## Test plan

- [ ] Deploy subgraph and verify tasks with decimal estHours (like 0.5) are indexed correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)