### PR TITLE
Add Task to TaskMetadata entities list

### DIFF
--- a/pop-subgraph/subgraph.yaml
+++ b/pop-subgraph/subgraph.yaml
@@ -809,6 +809,7 @@ templates:
       handler: handleTaskMetadata
       entities:
         - TaskMetadata
+        - Task
       abis:
         - name: TaskManager
           file: ./abis/TaskManager.json


### PR DESCRIPTION
## Summary
- Fixes indexing error: `entity type 'Task' is not on the 'entities' list for data source 'TaskMetadata'`
- The `handleTaskMetadata` handler updates Task entities to link metadata, so Task must be declared in the entities list

## Root Cause
In `task-metadata.ts`, the handler updates the parent Task entity:
```typescript
let task = Task.load(taskId);
if (task) {
  if (metadataType == "submission") {
    task.submissionMetadata = ipfsHash;
  } else {
    task.metadata = ipfsHash;
  }
  task.save();
}
```

This requires Task to be in the entities list for the TaskMetadata data source.

## Test plan
- [ ] Deploy subgraph and verify no indexing errors
- [ ] Create a task and confirm TaskMetadata is indexed
- [ ] Submit a task and confirm submission metadata is indexed

🤖 Generated with [Claude Code](https://claude.com/claude-code)