### PR TITLE
Refactor: Store submission directly on Task entity

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -257,8 +257,8 @@ type Task @entity(immutable: false) {
   title: String! # task title
   metadataHash: Bytes! # task metadata hash (description, difficulty, estHours)
   submissionHash: Bytes # submission metadata hash (set when task is submitted)
+  submission: String # submission text (parsed from IPFS, stored directly on task)
   metadata: TaskMetadata # Link to indexed task metadata from IPFS
-  submissionMetadata: TaskMetadata # Link to indexed submission metadata from IPFS
   assignee: Bytes
   assigneeUsername: String
   assigneeUser: User
@@ -280,8 +280,8 @@ type Task @entity(immutable: false) {
 }
 
 """
-Task metadata fetched from IPFS.
-Contains task description, difficulty, estimated hours, and submission text.
+Task creation metadata fetched from IPFS.
+Contains task description, difficulty, and estimated hours.
 """
 type TaskMetadata @entity(immutable: false) {
   id: String! # IPFS CID (Qm...)
@@ -291,7 +291,6 @@ type TaskMetadata @entity(immutable: false) {
   location: String # Task location/status from IPFS JSON
   difficulty: String # Task difficulty (easy, medium, hard, etc.)
   estimatedHours: Int # Estimated hours to complete
-  submission: String # Submission text (populated for submission metadata)
   indexedAt: BigInt
 }
 

--- a/pop-subgraph/src/task-manager.ts
+++ b/pop-subgraph/src/task-manager.ts
@@ -204,14 +204,9 @@ export function handleTaskSubmitted(event: TaskSubmitted): void {
     task.submittedAt = event.block.timestamp;
     // Store submission hash separately - don't overwrite original task metadata
     task.submissionHash = event.params.submissionHash;
-
-    // Set submission metadata link (CID) for the TaskMetadata entity
-    let submissionCid = bytes32ToCid(event.params.submissionHash);
-    task.submissionMetadata = submissionCid;
-
     task.save();
 
-    // Create IPFS data source to fetch and index submission metadata
+    // Create IPFS data source to fetch and parse submission text
     createTaskMetadataSource(event.params.submissionHash, id, "submission");
   }
 }


### PR DESCRIPTION
## Summary
- Simplifies the data model by storing submission text directly on the Task entity
- Removes redundant `submissionMetadata` link and cleans up TaskMetadata entity
- TaskMetadata now only holds task creation metadata (description, difficulty, etc.)

## Changes
- **schema.graphql**: Added `submission: String` to Task, removed `submissionMetadata` link, removed `submission` from TaskMetadata
- **task-metadata.ts**: For submissions, stores text directly on `task.submission` instead of creating a separate entity
- **task-manager.ts**: Removed redundant `submissionMetadata` assignment

## Data Model (Before → After)
**Before:**
- `task.metadata` → TaskMetadata (description, difficulty, etc.)
- `task.submissionMetadata` → TaskMetadata (submission text) ❌ bloat

**After:**
- `task.metadata` → TaskMetadata (description, difficulty, etc.)
- `task.submission` → String (submission text directly) ✅ clean

## Breaking Changes
Frontend needs to update queries:
- Change `submissionMetadata { submission }` to just `submission`

## Test plan
- [ ] Deploy subgraph
- [ ] Create a task and verify metadata is indexed
- [ ] Submit a task and verify `task.submission` is populated
- [ ] Verify no TaskMetadata entity is created for submissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)