### PR TITLE
Debug: Verify IPFS handler triggers for submissions

### DIFF
--- a/pop-subgraph/src/task-metadata.ts
+++ b/pop-subgraph/src/task-metadata.ts
@@ -35,6 +35,16 @@ export function handleTaskMetadata(content: Bytes): void {
   let taskId = context.getString("taskId");
   let metadataType = context.getString("metadataType"); // "task" or "submission"
 
+  // ALWAYS create an entity with the IPFS hash to verify handler is running
+  // This helps debug whether the handler is being triggered at all
+  let debugEntity = TaskMetadata.load(ipfsHash);
+  if (debugEntity == null) {
+    debugEntity = new TaskMetadata(ipfsHash);
+    debugEntity.task = taskId;
+    debugEntity.indexedAt = BigInt.fromI32(0);
+    debugEntity.save();
+  }
+
   // Try to parse the JSON content
   let jsonResult = json.try_fromBytes(content);
   if (jsonResult.isError) {


### PR DESCRIPTION
## Summary

Adds debug code to determine if the IPFS file data source handler is being triggered for submission hashes.

## The Change

Creates a TaskMetadata entity with the IPFS CID as ID at the **very start** of the handler, before any other logic. This ensures we can detect if the handler runs at all.

## After Deployment

Query for entities with submission CIDs:
```graphql
{
  t1: taskMetadata(id: "QmPHk1GiZhGMbHaL7WJXjTvdVToLSA9S1t5889qiYQ4K8X") { id }
  t2: taskMetadata(id: "QmRyBK5xRHSq4M3nQ7jhot484rXHQsHqmqz2VrQ9ApgzVc") { id }
  t3: taskMetadata(id: "QmddsR4HR1KWVMDBkztpnur49CQk2nCPTFBJu76d6BkAUa") { id }
}
```

**If these entities exist**: The IPFS handler IS being triggered, issue is in logic.
**If these entities don't exist**: The IPFS data source creation is failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)