### PR TITLE
Fix: Robust metadata handler - always create entity and link

### DIFF
--- a/pop-subgraph/src/task-metadata.ts
+++ b/pop-subgraph/src/task-metadata.ts
@@ -3,53 +3,52 @@ import { TaskMetadata, Task } from "../generated/schema";
 
 /**
  * Handler for IPFS file data source that parses task metadata JSON.
- *
- * This handler processes BOTH task creation metadata AND submission metadata.
- * The JSON structure is the same for both, but submission will have a non-empty
- * "submission" field.
- *
- * Key insight: We ALWAYS update/create the metadata entity pointed to by task.metadata,
- * regardless of which IPFS source triggered this handler. This ensures submission
- * data ends up in the right place.
+ * Processes both task creation and submission metadata, storing all data
+ * in a single TaskMetadata entity linked to the task.
  */
 export function handleTaskMetadata(content: Bytes): void {
   let ipfsHash = dataSource.stringParam();
   let context = dataSource.context();
   let taskId = context.getString("taskId");
 
-  // Load the task to get the canonical metadata CID
-  let task = Task.load(taskId);
-  if (!task) {
-    return;
-  }
-
-  // The canonical metadata CID is set by handleTaskCreated
-  let canonicalMetadataCid = task.metadata;
-  if (!canonicalMetadataCid) {
-    return;
+  // Load or create the TaskMetadata entity using the IPFS hash as ID
+  let metadata = TaskMetadata.load(ipfsHash);
+  if (metadata == null) {
+    metadata = new TaskMetadata(ipfsHash);
+    metadata.task = taskId;
+    metadata.indexedAt = BigInt.fromI32(0);
   }
 
   // Try to parse the JSON content
   let jsonResult = json.try_fromBytes(content);
   if (jsonResult.isError) {
+    // Even if JSON parsing fails, save the entity so it exists
+    metadata.save();
+
+    // Link task to this metadata
+    let task = Task.load(taskId);
+    if (task) {
+      task.metadata = ipfsHash;
+      task.save();
+    }
     return;
   }
 
   let jsonValue = jsonResult.value;
   if (jsonValue.isNull() || jsonValue.kind != JSONValueKind.OBJECT) {
+    metadata.save();
+
+    let task = Task.load(taskId);
+    if (task) {
+      task.metadata = ipfsHash;
+      task.save();
+    }
     return;
   }
 
   let jsonObject = jsonValue.toObject();
 
-  // Load or create the canonical metadata entity
-  let metadata = TaskMetadata.load(canonicalMetadataCid!);
-  if (metadata == null) {
-    metadata = new TaskMetadata(canonicalMetadataCid!);
-    metadata.task = taskId;
-  }
-
-  // Parse submission text - if present, this is submission metadata
+  // Parse submission text
   let submissionValue = jsonObject.get("submission");
   if (submissionValue != null && !submissionValue.isNull() && submissionValue.kind == JSONValueKind.STRING) {
     let text = submissionValue.toString();
@@ -58,45 +57,57 @@ export function handleTaskMetadata(content: Bytes): void {
     }
   }
 
-  // Parse other fields - these come from task creation metadata
-  // Only update if the field isn't already set (to preserve data from other IPFS source)
+  // Parse name
   let nameValue = jsonObject.get("name");
   if (nameValue != null && !nameValue.isNull() && nameValue.kind == JSONValueKind.STRING) {
-    if (!metadata.name) {
-      metadata.name = nameValue.toString();
-    }
+    metadata.name = nameValue.toString();
   }
 
+  // Parse description
   let descriptionValue = jsonObject.get("description");
   if (descriptionValue != null && !descriptionValue.isNull() && descriptionValue.kind == JSONValueKind.STRING) {
-    // Description might be empty string in submission JSON, so check task creation
-    let desc = descriptionValue.toString();
-    if (desc.length > 0 || !metadata.description) {
-      metadata.description = desc;
-    }
+    metadata.description = descriptionValue.toString();
   }
 
+  // Parse location
   let locationValue = jsonObject.get("location");
   if (locationValue != null && !locationValue.isNull() && locationValue.kind == JSONValueKind.STRING) {
-    if (!metadata.location) {
-      metadata.location = locationValue.toString();
-    }
+    metadata.location = locationValue.toString();
   }
 
+  // Parse difficulty
   let difficultyValue = jsonObject.get("difficulty");
   if (difficultyValue != null && !difficultyValue.isNull() && difficultyValue.kind == JSONValueKind.STRING) {
-    if (!metadata.difficulty) {
-      metadata.difficulty = difficultyValue.toString();
-    }
+    metadata.difficulty = difficultyValue.toString();
   }
 
+  // Parse estHours
   let estHoursValue = jsonObject.get("estHours");
   if (estHoursValue != null && !estHoursValue.isNull() && estHoursValue.kind == JSONValueKind.NUMBER) {
-    if (!metadata.estimatedHours) {
-      metadata.estimatedHours = i32(Math.round(estHoursValue.toF64()));
-    }
+    metadata.estimatedHours = i32(Math.round(estHoursValue.toF64()));
   }
 
-  metadata.indexedAt = BigInt.fromI32(0);
   metadata.save();
+
+  // Link task to this metadata entity
+  let task = Task.load(taskId);
+  if (task) {
+    // For task creation IPFS, set task.metadata to this entity
+    // For submission IPFS, we also need to update the task's metadata entity with submission
+    if (!task.metadata || task.metadata == ipfsHash) {
+      // This is task creation IPFS or updating existing
+      task.metadata = ipfsHash;
+      task.save();
+    } else {
+      // This is submission IPFS - need to update the TASK's metadata entity
+      // task.metadata points to task creation CID, we need to copy submission there
+      let taskMetadata = TaskMetadata.load(task.metadata!);
+      if (taskMetadata) {
+        if (metadata.submission) {
+          taskMetadata.submission = metadata.submission;
+          taskMetadata.save();
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Fixes the issue where metadata became null after the last deployment.

## What Went Wrong

The previous simplified handler was checking `task.metadata` before creating the TaskMetadata entity. This caused issues because the handler was returning early.

## The Fix

1. **Always create TaskMetadata entity** - Use `ipfsHash` as the entity ID
2. **Always save the entity** - Never return without saving
3. **Always link task.metadata** - Set `task.metadata = ipfsHash` for task creation
4. **Copy submission to task metadata** - For submission IPFS, also update the task's canonical metadata entity

## Logic

```
Task Creation IPFS:
  - Create TaskMetadata(ipfsHash) with description, etc.
  - Set task.metadata = ipfsHash
  
Submission IPFS:
  - Create TaskMetadata(ipfsHash) with submission
  - If task.metadata != ipfsHash (different entity):
    - Copy submission to TaskMetadata(task.metadata)
```

## Test Plan
- [ ] Deploy without grafting
- [ ] Verify `task.metadata` is not null
- [ ] Verify `task.metadata.description` is populated
- [ ] Verify `task.metadata.submission` is populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)