### PR TITLE
Fix: Task submission metadata now properly populates

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -257,7 +257,8 @@ type Task @entity(immutable: false) {
   title: String! # task title
   metadataHash: Bytes! # task metadata hash (description, difficulty, estHours)
   submissionHash: Bytes # submission metadata hash (set when task is submitted)
-  metadata: TaskMetadata # Link to indexed metadata from IPFS (includes submission when submitted)
+  metadata: TaskMetadata # Link to indexed task creation metadata from IPFS
+  submissionMetadata: TaskMetadata # Link to indexed submission metadata from IPFS
   assignee: Bytes
   assigneeUsername: String
   assigneeUser: User


### PR DESCRIPTION
## Summary

Fixed the bug where submission metadata wasn't being populated in the subgraph. The original code attempted a flawed dual-entity merge pattern that failed due to IPFS handler ordering race conditions.

## Changes

- Added `submissionMetadata` field to Task entity for submission-specific IPFS metadata
- Simplified task-metadata handler to cleanly route IPFS data by metadataType context
- Removed error-prone cross-entity copying logic
- Submission text now reliably accessible via `task.submissionMetadata.submission`

## Testing

- `npm run codegen` ✓
- `npm run build` ✓
- `npm run test` ✓ (184 tests passed)
- `subgraph-lint` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)