### PR TITLE
Fix: Pre-set submissionMetadata link in event handler

### DIFF
--- a/pop-subgraph/src/task-manager.ts
+++ b/pop-subgraph/src/task-manager.ts
@@ -204,6 +204,12 @@ export function handleTaskSubmitted(event: TaskSubmitted): void {
     task.submittedAt = event.block.timestamp;
     // Store submission hash separately - don't overwrite original task metadata
     task.submissionHash = event.params.submissionHash;
+
+    // Pre-set the submissionMetadata link (mirrors handleTaskCreated which pre-sets metadata)
+    // The IPFS handler will create the TaskMetadata entity with this CID as its ID
+    let submissionCid = bytes32ToCid(event.params.submissionHash);
+    task.submissionMetadata = submissionCid;
+
     task.save();
 
     // Create IPFS data source to fetch and parse submission text

--- a/pop-subgraph/src/task-metadata.ts
+++ b/pop-subgraph/src/task-metadata.ts
@@ -115,12 +115,28 @@ function linkMetadataToTask(
     let isSubmission = metadataType == "submission" || hasSubmissionContent;
 
     if (isSubmission) {
+      // Only set submissionMetadata, preserve existing metadata link
       task.submissionMetadata = ipfsHash;
-      log.info("Linked submission metadata {} to task {}", [ipfsHash, taskId]);
+      log.info("Linked submission metadata {} to task {} (context={}, hasContent={})", [
+        ipfsHash,
+        taskId,
+        metadataType,
+        hasSubmissionContent ? "true" : "false"
+      ]);
     } else {
-      task.metadata = ipfsHash;
-      log.info("Linked task metadata {} to task {}", [ipfsHash, taskId]);
+      // Only set metadata if not already set (task creation handler pre-sets it)
+      if (task.metadata == null) {
+        task.metadata = ipfsHash;
+      }
+      log.info("Linked task metadata {} to task {} (context={}, hasContent={})", [
+        ipfsHash,
+        taskId,
+        metadataType,
+        hasSubmissionContent ? "true" : "false"
+      ]);
     }
     task.save();
+  } else {
+    log.warning("Task {} not found when trying to link metadata {}", [taskId, ipfsHash]);
   }
 }


### PR DESCRIPTION
## Summary

Fixes the issue where `task.submissionMetadata` was null even though TaskMetadata entities with submission content existed.

## Root Cause

The previous fixes relied on the IPFS file data source handler to set `task.submissionMetadata`. However, IPFS handlers run asynchronously and their entity changes may not reliably persist back to the parent Task entity.

Looking at how `handleTaskCreated` works: it **pre-sets** `task.metadata = cid` in the event handler before the IPFS handler runs. This guarantees the link exists.

`handleTaskSubmitted` was NOT doing this - it only set `task.submissionHash` and relied entirely on the IPFS handler to set `task.submissionMetadata`.

## Solution

Modified `handleTaskSubmitted` to pre-set the `submissionMetadata` link:

```typescript
let submissionCid = bytes32ToCid(event.params.submissionHash);
task.submissionMetadata = submissionCid;
```

This mirrors the pattern used in `handleTaskCreated` and ensures the link is set synchronously during event processing.

## Changes

- `task-manager.ts`: Pre-set `task.submissionMetadata` in `handleTaskSubmitted`
- `task-metadata.ts`: Added defensive logging and content-based detection fallback

## Testing

- `npm run codegen` ✓
- `npm run build` ✓
- `npm run test` ✓ (184 tests passed)
- `subgraph-lint` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)