### PR TITLE
Remove submission field from TaskMetadata entity

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -281,8 +281,7 @@ type Task @entity(immutable: false) {
 
 """
 Task metadata fetched from IPFS.
-Contains task description, difficulty, estimated hours, and submission text.
-Used for both task creation metadata and submission metadata.
+Contains task description, difficulty, and estimated hours.
 """
 type TaskMetadata @entity(immutable: false) {
   id: String! # IPFS CID (Qm...)
@@ -292,7 +291,6 @@ type TaskMetadata @entity(immutable: false) {
   location: String # Task location/status from IPFS JSON
   difficulty: String # Task difficulty (easy, medium, hard, etc.)
   estimatedHours: Int # Estimated hours to complete
-  submission: String # Submission text (populated for submission metadata)
   indexedAt: BigInt
 }
 

--- a/pop-subgraph/src/task-metadata.ts
+++ b/pop-subgraph/src/task-metadata.ts
@@ -1,24 +1,17 @@
-import { Bytes, dataSource, json, BigInt, JSONValueKind, log } from "@graphprotocol/graph-ts";
+import { Bytes, dataSource, json, BigInt, JSONValueKind } from "@graphprotocol/graph-ts";
 import { TaskMetadata, Task } from "../generated/schema";
 
 /**
  * Handler for IPFS file data source that parses task metadata JSON.
  *
- * Each IPFS hash creates its own TaskMetadata entity. The handler determines
- * whether this is task creation metadata or submission metadata by:
- * 1. First checking the metadataType context (if reliably set)
- * 2. Falling back to content detection: if JSON has non-empty "submission" field
- *    AND location is "In Review", it's submission metadata
- *
- * Links the entity to the correct field on the Task:
- * - Task creation -> task.metadata
- * - Submission -> task.submissionMetadata
+ * Creates a TaskMetadata entity with parsed fields from the IPFS JSON content.
+ * The Task entity links are pre-set by the event handlers (handleTaskCreated
+ * and handleTaskSubmitted), so this handler only needs to populate the metadata.
  */
 export function handleTaskMetadata(content: Bytes): void {
   let ipfsHash = dataSource.stringParam();
   let context = dataSource.context();
   let taskId = context.getString("taskId");
-  let metadataType = context.getString("metadataType");
 
   // Load or create the TaskMetadata entity using the IPFS hash as ID
   let metadata = TaskMetadata.load(ipfsHash);
@@ -31,31 +24,17 @@ export function handleTaskMetadata(content: Bytes): void {
   // Try to parse the JSON content
   let jsonResult = json.try_fromBytes(content);
   if (jsonResult.isError) {
-    // Even if JSON parsing fails, save the entity and link to task
     metadata.save();
-    linkMetadataToTask(taskId, ipfsHash, metadataType, false);
     return;
   }
 
   let jsonValue = jsonResult.value;
   if (jsonValue.isNull() || jsonValue.kind != JSONValueKind.OBJECT) {
     metadata.save();
-    linkMetadataToTask(taskId, ipfsHash, metadataType, false);
     return;
   }
 
   let jsonObject = jsonValue.toObject();
-
-  // Parse submission text and track if it has content
-  let hasSubmissionContent = false;
-  let submissionValue = jsonObject.get("submission");
-  if (submissionValue != null && !submissionValue.isNull() && submissionValue.kind == JSONValueKind.STRING) {
-    let text = submissionValue.toString();
-    if (text.length > 0) {
-      metadata.submission = text;
-      hasSubmissionContent = true;
-    }
-  }
 
   // Parse name
   let nameValue = jsonObject.get("name");
@@ -88,55 +67,4 @@ export function handleTaskMetadata(content: Bytes): void {
   }
 
   metadata.save();
-  linkMetadataToTask(taskId, ipfsHash, metadataType, hasSubmissionContent);
-}
-
-/**
- * Links the TaskMetadata entity to the Task based on metadata type.
- *
- * Uses dual detection strategy:
- * 1. If metadataType context is "submission", use that
- * 2. Otherwise, if JSON content has non-empty submission text, treat as submission
- * 3. Default to task metadata
- *
- * This handles cases where context may not be preserved across indexer restarts.
- */
-function linkMetadataToTask(
-  taskId: string,
-  ipfsHash: string,
-  metadataType: string,
-  hasSubmissionContent: boolean
-): void {
-  let task = Task.load(taskId);
-  if (task) {
-    // Determine if this is submission metadata using dual detection:
-    // 1. Context says "submission", OR
-    // 2. JSON content has actual submission text (content-based detection)
-    let isSubmission = metadataType == "submission" || hasSubmissionContent;
-
-    if (isSubmission) {
-      // Only set submissionMetadata, preserve existing metadata link
-      task.submissionMetadata = ipfsHash;
-      log.info("Linked submission metadata {} to task {} (context={}, hasContent={})", [
-        ipfsHash,
-        taskId,
-        metadataType,
-        hasSubmissionContent ? "true" : "false"
-      ]);
-    } else {
-      // Only set metadata if not already set (task creation handler pre-sets it)
-      if (task.metadata == null) {
-        task.metadata = ipfsHash;
-      }
-      log.info("Linked task metadata {} to task {} (context={}, hasContent={})", [
-        ipfsHash,
-        taskId,
-        metadataType,
-        hasSubmissionContent ? "true" : "false"
-      ]);
-    }
-    task.save();
-  } else {
-    log.warning("Task {} not found when trying to link metadata {}", [taskId, ipfsHash]);
-  }
 }


### PR DESCRIPTION
## Summary

Removes the `submission` field from the `TaskMetadata` entity since it's no longer needed.

## Why

Now that `task.submissionMetadata` is properly linked (pre-set in `handleTaskSubmitted`), the submission text is accessed through a separate TaskMetadata entity. The `submission` field on the shared TaskMetadata type is redundant.

## Changes

- Removed `submission: String` from TaskMetadata schema
- Simplified task-metadata IPFS handler to only parse metadata fields (no linking logic needed since event handlers pre-set links)

## Testing

- `npm run codegen` ✓
- `npm run build` ✓
- `npm run test` ✓ (184 tests passed)
- `subgraph-lint` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)