### PR TITLE
Add separate TaskMetadata and SubmissionMetadata entities

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -256,6 +256,9 @@ type Task @entity(immutable: false) {
   requiresApplication: Boolean!
   title: String! # task title
   metadataHash: Bytes! # task metadata hash
+  metadata: TaskMetadata # Link to indexed task creation metadata from IPFS
+  submissionHash: Bytes # hash of submission data
+  submissionMetadata: SubmissionMetadata # Link to indexed submission metadata from IPFS
   assignee: Bytes
   assigneeUsername: String
   assigneeUser: User
@@ -274,6 +277,32 @@ type Task @entity(immutable: false) {
   cancelledAt: BigInt
   updatedAt: BigInt
   applications: [TaskApplication!]! @derivedFrom(field: "task")
+}
+
+"""
+Task metadata fetched from IPFS.
+Contains task description, difficulty, and estimated hours.
+"""
+type TaskMetadata @entity(immutable: false) {
+  id: String! # IPFS CID (Qm...)
+  task: Task
+  name: String # Task name from IPFS JSON
+  description: String # Task description from IPFS JSON
+  location: String # Task location/status from IPFS JSON
+  difficulty: String # Task difficulty (easy, medium, hard, etc.)
+  estimatedHours: Int # Estimated hours to complete
+  indexedAt: BigInt
+}
+
+"""
+Submission metadata fetched from IPFS.
+Contains the raw submission text for a completed task.
+"""
+type SubmissionMetadata @entity(immutable: false) {
+  id: String! # IPFS CID (Qm...)
+  task: Task
+  submission: String # Raw submission text from IPFS JSON
+  indexedAt: BigInt
 }
 
 type TaskApplication @entity(immutable: false) {

--- a/pop-subgraph/src/submission-metadata.ts
+++ b/pop-subgraph/src/submission-metadata.ts
@@ -1,0 +1,49 @@
+import { Bytes, dataSource, json, BigInt, JSONValueKind } from "@graphprotocol/graph-ts";
+import { SubmissionMetadata } from "../generated/schema";
+
+/**
+ * Handler for IPFS file data source that parses submission metadata JSON.
+ *
+ * Creates a SubmissionMetadata entity with the raw submission text.
+ * The Task entity link is pre-set by the event handler (handleTaskSubmitted),
+ * so this handler only needs to populate the submission field.
+ */
+export function handleSubmissionMetadata(content: Bytes): void {
+  let ipfsHash = dataSource.stringParam();
+  let context = dataSource.context();
+  let taskId = context.getString("taskId");
+
+  // Load or create the SubmissionMetadata entity using the IPFS hash as ID
+  let metadata = SubmissionMetadata.load(ipfsHash);
+  if (metadata == null) {
+    metadata = new SubmissionMetadata(ipfsHash);
+    metadata.task = taskId;
+    metadata.indexedAt = BigInt.fromI32(0);
+  }
+
+  // Try to parse the JSON content
+  let jsonResult = json.try_fromBytes(content);
+  if (jsonResult.isError) {
+    metadata.save();
+    return;
+  }
+
+  let jsonValue = jsonResult.value;
+  if (jsonValue.isNull() || jsonValue.kind != JSONValueKind.OBJECT) {
+    metadata.save();
+    return;
+  }
+
+  let jsonObject = jsonValue.toObject();
+
+  // Parse submission text
+  let submissionValue = jsonObject.get("submission");
+  if (submissionValue != null && !submissionValue.isNull() && submissionValue.kind == JSONValueKind.STRING) {
+    let text = submissionValue.toString();
+    if (text.length > 0) {
+      metadata.submission = text;
+    }
+  }
+
+  metadata.save();
+}

--- a/pop-subgraph/src/task-manager.ts
+++ b/pop-subgraph/src/task-manager.ts
@@ -1,4 +1,5 @@
-import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts";
+import { Address, BigInt, Bytes, DataSourceContext } from "@graphprotocol/graph-ts";
+import { TaskMetadata as TaskMetadataTemplate, SubmissionMetadata as SubmissionMetadataTemplate } from "../generated/templates";
 import {
   ProjectCreated,
   ProjectDeleted,
@@ -36,6 +37,74 @@ import { getUsernameForAddress, getOrCreateUser } from "./utils";
  */
 function getProjectEntityId(taskManagerAddress: Address, projectId: Bytes): string {
   return taskManagerAddress.toHexString() + "-" + projectId.toHexString();
+}
+
+/**
+ * Convert bytes32 sha256 digest to IPFS CIDv0 string.
+ * The contract stores only the 32-byte hash, we need to prepend
+ * the multihash prefix (0x1220) and base58 encode.
+ */
+function bytes32ToCid(hash: Bytes): string {
+  // Create the multihash by prepending 0x1220 header
+  let prefix = Bytes.fromHexString("0x1220");
+
+  // Concatenate prefix + hash (34 bytes total)
+  let multihash = new Bytes(34);
+  for (let i = 0; i < 2; i++) {
+    multihash[i] = prefix[i];
+  }
+  for (let i = 0; i < 32; i++) {
+    multihash[i + 2] = hash[i];
+  }
+
+  // Base58 encode to get CIDv0 (starts with "Qm")
+  return multihash.toBase58();
+}
+
+/**
+ * Helper function to create an IPFS file data source for task metadata.
+ * Uses DataSourceContext to pass the taskId to the handler
+ * so it can link the metadata back to the task.
+ */
+function createTaskMetadataSource(metadataHash: Bytes, taskId: string): void {
+  // Skip if metadataHash is empty (all zeros)
+  let zeroHash = Bytes.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000000");
+  if (metadataHash.equals(zeroHash)) {
+    return;
+  }
+
+  // Convert bytes32 sha256 digest to IPFS CIDv0 string
+  let ipfsCid = bytes32ToCid(metadataHash);
+
+  // Create context to pass taskId to the IPFS handler
+  let context = new DataSourceContext();
+  context.setString("taskId", taskId);
+
+  // Create the file data source with context
+  TaskMetadataTemplate.createWithContext(ipfsCid, context);
+}
+
+/**
+ * Helper function to create an IPFS file data source for submission metadata.
+ * Uses DataSourceContext to pass the taskId to the handler
+ * so it can link the submission back to the task.
+ */
+function createSubmissionMetadataSource(submissionHash: Bytes, taskId: string): void {
+  // Skip if submissionHash is empty (all zeros)
+  let zeroHash = Bytes.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000000");
+  if (submissionHash.equals(zeroHash)) {
+    return;
+  }
+
+  // Convert bytes32 sha256 digest to IPFS CIDv0 string
+  let ipfsCid = bytes32ToCid(submissionHash);
+
+  // Create context to pass taskId to the IPFS handler
+  let context = new DataSourceContext();
+  context.setString("taskId", taskId);
+
+  // Create the file data source with context
+  SubmissionMetadataTemplate.createWithContext(ipfsCid, context);
 }
 
 /**
@@ -92,7 +161,14 @@ export function handleTaskCreated(event: TaskCreated): void {
   task.createdAt = event.block.timestamp;
   task.createdAtBlock = event.block.number;
 
+  // Set metadata link (CID) for the TaskMetadata entity that will be created by IPFS handler
+  let metadataCid = bytes32ToCid(event.params.metadataHash);
+  task.metadata = metadataCid;
+
   task.save();
+
+  // Create IPFS data source to fetch and index task metadata
+  createTaskMetadataSource(event.params.metadataHash, id);
 }
 
 export function handleTaskAssigned(event: TaskAssigned): void {
@@ -148,9 +224,18 @@ export function handleTaskSubmitted(event: TaskSubmitted): void {
   if (task) {
     task.status = "Submitted";
     task.submittedAt = event.block.timestamp;
-    // submissionHash is now bytes32 - store in metadataHash
-    task.metadataHash = event.params.submissionHash;
+    // Store submission hash separately - don't overwrite original task metadata
+    task.submissionHash = event.params.submissionHash;
+
+    // Pre-set the submissionMetadata link (mirrors handleTaskCreated which pre-sets metadata)
+    // The IPFS handler will create the SubmissionMetadata entity with this CID as its ID
+    let submissionCid = bytes32ToCid(event.params.submissionHash);
+    task.submissionMetadata = submissionCid;
+
     task.save();
+
+    // Create IPFS data source to fetch and parse submission text
+    createSubmissionMetadataSource(event.params.submissionHash, id);
   }
 }
 
@@ -233,13 +318,28 @@ export function handleTaskUpdated(event: TaskUpdated): void {
 
   let task = Task.load(id);
   if (task) {
+    // Check if metadata changed before updating
+    let metadataChanged = !task.metadataHash.equals(event.params.metadataHash);
+
     task.payout = event.params.payout;
     task.bountyToken = event.params.bountyToken;
     task.bountyPayout = event.params.bountyPayout;
     task.title = event.params.title.toString();
     task.metadataHash = event.params.metadataHash;
     task.updatedAt = event.block.timestamp;
+
+    // Update metadata link if changed
+    if (metadataChanged) {
+      let metadataCid = bytes32ToCid(event.params.metadataHash);
+      task.metadata = metadataCid;
+    }
+
     task.save();
+
+    // Re-fetch metadata from IPFS if it changed
+    if (metadataChanged) {
+      createTaskMetadataSource(event.params.metadataHash, id);
+    }
   }
 }
 

--- a/pop-subgraph/src/task-metadata.ts
+++ b/pop-subgraph/src/task-metadata.ts
@@ -1,0 +1,70 @@
+import { Bytes, dataSource, json, BigInt, JSONValueKind } from "@graphprotocol/graph-ts";
+import { TaskMetadata } from "../generated/schema";
+
+/**
+ * Handler for IPFS file data source that parses task metadata JSON.
+ *
+ * Creates a TaskMetadata entity with parsed fields from the IPFS JSON content.
+ * The Task entity link is pre-set by the event handler (handleTaskCreated),
+ * so this handler only needs to populate the metadata fields.
+ */
+export function handleTaskMetadata(content: Bytes): void {
+  let ipfsHash = dataSource.stringParam();
+  let context = dataSource.context();
+  let taskId = context.getString("taskId");
+
+  // Load or create the TaskMetadata entity using the IPFS hash as ID
+  let metadata = TaskMetadata.load(ipfsHash);
+  if (metadata == null) {
+    metadata = new TaskMetadata(ipfsHash);
+    metadata.task = taskId;
+    metadata.indexedAt = BigInt.fromI32(0);
+  }
+
+  // Try to parse the JSON content
+  let jsonResult = json.try_fromBytes(content);
+  if (jsonResult.isError) {
+    metadata.save();
+    return;
+  }
+
+  let jsonValue = jsonResult.value;
+  if (jsonValue.isNull() || jsonValue.kind != JSONValueKind.OBJECT) {
+    metadata.save();
+    return;
+  }
+
+  let jsonObject = jsonValue.toObject();
+
+  // Parse name
+  let nameValue = jsonObject.get("name");
+  if (nameValue != null && !nameValue.isNull() && nameValue.kind == JSONValueKind.STRING) {
+    metadata.name = nameValue.toString();
+  }
+
+  // Parse description
+  let descriptionValue = jsonObject.get("description");
+  if (descriptionValue != null && !descriptionValue.isNull() && descriptionValue.kind == JSONValueKind.STRING) {
+    metadata.description = descriptionValue.toString();
+  }
+
+  // Parse location
+  let locationValue = jsonObject.get("location");
+  if (locationValue != null && !locationValue.isNull() && locationValue.kind == JSONValueKind.STRING) {
+    metadata.location = locationValue.toString();
+  }
+
+  // Parse difficulty
+  let difficultyValue = jsonObject.get("difficulty");
+  if (difficultyValue != null && !difficultyValue.isNull() && difficultyValue.kind == JSONValueKind.STRING) {
+    metadata.difficulty = difficultyValue.toString();
+  }
+
+  // Parse estHours
+  let estHoursValue = jsonObject.get("estHours");
+  if (estHoursValue != null && !estHoursValue.isNull() && estHoursValue.kind == JSONValueKind.NUMBER) {
+    metadata.estimatedHours = i32(Math.round(estHoursValue.toF64()));
+  }
+
+  metadata.save();
+}

--- a/pop-subgraph/subgraph.yaml
+++ b/pop-subgraph/subgraph.yaml
@@ -796,3 +796,33 @@ templates:
       abis:
         - name: EligibilityModule
           file: ./abis/EligibilityModule.json
+  # IPFS file data source for task metadata
+  - kind: file/ipfs
+    name: TaskMetadata
+    network: hoodi
+    mapping:
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      file: ./src/task-metadata.ts
+      handler: handleTaskMetadata
+      entities:
+        - TaskMetadata
+        - Task
+      abis:
+        - name: TaskManager
+          file: ./abis/TaskManager.json
+  # IPFS file data source for submission metadata
+  - kind: file/ipfs
+    name: SubmissionMetadata
+    network: hoodi
+    mapping:
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      file: ./src/submission-metadata.ts
+      handler: handleSubmissionMetadata
+      entities:
+        - SubmissionMetadata
+        - Task
+      abis:
+        - name: TaskManager
+          file: ./abis/TaskManager.json


### PR DESCRIPTION
## Summary

- Adds `TaskMetadata` entity for task creation metadata (name, description, location, difficulty, estimatedHours)
- Adds `SubmissionMetadata` entity for submission data (raw submission text)
- Adds `Task.metadata` and `Task.submissionMetadata` fields linking to IPFS-indexed data
- Adds `Task.submissionHash` field to store submission hash separately from `metadataHash`
- Creates separate IPFS file data source templates for each metadata type
- Pre-sets entity links in event handlers for reliable IPFS handler linking

## Test plan

- [x] `npm run codegen` passes
- [x] `npm run build` passes  
- [x] `npm run test` passes (184 tests)
- [x] `subgraph-lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)