### PR TITLE
Merge task and submission metadata into single entity

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -257,8 +257,7 @@ type Task @entity(immutable: false) {
   title: String! # task title
   metadataHash: Bytes! # task metadata hash (description, difficulty, estHours)
   submissionHash: Bytes # submission metadata hash (set when task is submitted)
-  metadata: TaskMetadata # Link to indexed task creation metadata from IPFS
-  submissionMetadata: TaskMetadata # Link to indexed submission metadata from IPFS
+  metadata: TaskMetadata # Link to indexed metadata from IPFS (updates to submission CID when task is submitted)
   assignee: Bytes
   assigneeUsername: String
   assigneeUser: User
@@ -281,16 +280,18 @@ type Task @entity(immutable: false) {
 
 """
 Task metadata fetched from IPFS.
-Contains task description, difficulty, and estimated hours.
+Contains task description, difficulty, estimated hours, and submission content.
+The entity ID changes to the submission hash when a task is submitted.
 """
 type TaskMetadata @entity(immutable: false) {
-  id: String! # IPFS CID (Qm...)
+  id: String! # IPFS CID (Qm...) - changes to submission CID when task is submitted
   task: Task
   name: String # Task name from IPFS JSON
   description: String # Task description from IPFS JSON
   location: String # Task location/status from IPFS JSON
   difficulty: String # Task difficulty (easy, medium, hard, etc.)
   estimatedHours: Int # Estimated hours to complete
+  submission: String # Submission content from IPFS JSON (populated when task is submitted)
   indexedAt: BigInt
 }
 

--- a/pop-subgraph/src/task-manager.ts
+++ b/pop-subgraph/src/task-manager.ts
@@ -202,17 +202,16 @@ export function handleTaskSubmitted(event: TaskSubmitted): void {
   if (task) {
     task.status = "Submitted";
     task.submittedAt = event.block.timestamp;
-    // Store submission hash separately - don't overwrite original task metadata
     task.submissionHash = event.params.submissionHash;
 
-    // Pre-set the submissionMetadata link (mirrors handleTaskCreated which pre-sets metadata)
-    // The IPFS handler will create the TaskMetadata entity with this CID as its ID
+    // Update metadata link to submission CID - the IPFS handler will create
+    // a new TaskMetadata entity with submission content included
     let submissionCid = bytes32ToCid(event.params.submissionHash);
-    task.submissionMetadata = submissionCid;
+    task.metadata = submissionCid;
 
     task.save();
 
-    // Create IPFS data source to fetch and parse submission text
+    // Create IPFS data source to fetch and parse submission metadata
     createTaskMetadataSource(event.params.submissionHash, id, "submission");
   }
 }

--- a/pop-subgraph/src/task-metadata.ts
+++ b/pop-subgraph/src/task-metadata.ts
@@ -66,5 +66,11 @@ export function handleTaskMetadata(content: Bytes): void {
     metadata.estimatedHours = i32(Math.round(estHoursValue.toF64()));
   }
 
+  // Parse submission content (populated when task is submitted)
+  let submissionValue = jsonObject.get("submission");
+  if (submissionValue != null && !submissionValue.isNull() && submissionValue.kind == JSONValueKind.STRING) {
+    metadata.submission = submissionValue.toString();
+  }
+
   metadata.save();
 }


### PR DESCRIPTION
## Summary

Consolidate task metadata and submission into a single TaskMetadata entity. Removes the separate submissionMetadata link and instead stores submission content in a new field within TaskMetadata. When a task is submitted, the metadata link updates to point to the submission CID.

## Changes

- Remove submissionMetadata field from Task entity
- Add submission field to TaskMetadata for storing submission content
- Update handleTaskSubmitted to change metadata link to submission CID
- Add submission parsing to IPFS metadata handler

All 184 tests pass and linting shows no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)