### PR TITLE
Add defaultEligible/defaultStanding to VouchConfig

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -634,6 +634,9 @@ type VouchConfig @entity(immutable: false) {
   membershipHatId: BigInt!
   enabled: Boolean!
   combinesWithHierarchy: Boolean!
+  # Default eligibility settings (synced from Hat entity via DefaultEligibilityUpdated event)
+  defaultEligible: Boolean!
+  defaultStanding: Boolean!
   updatedAt: BigInt!
   updatedAtBlock: BigInt!
   transactionHash: Bytes!


### PR DESCRIPTION
## Summary
Adds `defaultEligible` and `defaultStanding` fields to the VouchConfig entity, allowing direct queries without traversing to the Hat entity.

## Changes
- **schema.graphql**: Added `defaultEligible: Boolean!` and `defaultStanding: Boolean!` to VouchConfig
- **eligibility-module.ts**: 
  - `handleVouchConfigSet` now initializes defaults from Hat entity
  - `handleDefaultEligibilityUpdated` now syncs changes to VouchConfig

## Why
The frontend needs to query eligibility rules directly on VouchConfig. Previously, `defaultEligible` and `defaultStanding` were only on the Hat entity, requiring an extra join.

🤖 Generated with [Claude Code](https://claude.com/claude-code)