### PR TITLE
Update User.currentHatIds when eligibility changes

### DIFF
--- a/pop-subgraph/src/eligibility-module.ts
+++ b/pop-subgraph/src/eligibility-module.ts
@@ -231,6 +231,18 @@ export function handleWearerEligibilityUpdated(
       wearer,
       wearerEligibilityId
     );
+
+    // Update User.currentHatIds based on eligibility
+    let wearerUser = loadExistingUser(
+      eligibilityModule.organization,
+      wearer,
+      event.block.timestamp,
+      event.block.number
+    );
+    if (wearerUser) {
+      // Add or remove hat from currentHatIds based on active status
+      recordUserHatChange(wearerUser, hatId, isActive, event);
+    }
   }
 }
 
@@ -317,6 +329,18 @@ export function handleBulkWearerEligibilityUpdated(
         wearer,
         wearerEligibilityId
       );
+
+      // Update User.currentHatIds based on eligibility
+      let wearerUser = loadExistingUser(
+        eligibilityModule.organization,
+        wearer,
+        event.block.timestamp,
+        event.block.number
+      );
+      if (wearerUser) {
+        // Add or remove hat from currentHatIds based on active status
+        recordUserHatChange(wearerUser, hatId, isActive, event);
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
Fixes issue where users still appeared in role lists after losing eligibility because `User.currentHatIds` wasn't being updated.

## Problem
PR #77 fixed `RoleWearer.isActive` syncing with eligibility, but `User.currentHatIds` still contained the hatId. The frontend uses `currentHatIds` to display roles in the org structure page and leaderboard.

## Fix
When `WearerEligibilityUpdated` or `BulkWearerEligibilityUpdated` fires, now also calls `recordUserHatChange()` to add/remove the hatId from `User.currentHatIds` based on eligibility status.

- `isActive = true` → add hatId to currentHatIds
- `isActive = false` → remove hatId from currentHatIds

🤖 Generated with [Claude Code](https://claude.com/claude-code)