### PR TITLE
Update User.membershipStatus when user loses all active hats

### DIFF
--- a/pop-subgraph/src/utils.ts
+++ b/pop-subgraph/src/utils.ts
@@ -261,6 +261,11 @@ export function recordUserHatChange(
     if (!found) {
       currentHats.push(hatId);
       user.currentHatIds = currentHats;
+
+      // Reactivate user if they were inactive
+      if (user.membershipStatus == "Inactive") {
+        user.membershipStatus = "Active";
+      }
     }
   } else {
     // Remove hat if present
@@ -271,6 +276,11 @@ export function recordUserHatChange(
       }
     }
     user.currentHatIds = newHats;
+
+    // Update membershipStatus if user has no more active hats
+    if (newHats.length == 0) {
+      user.membershipStatus = "Inactive";
+    }
   }
 
   user.save();


### PR DESCRIPTION
## Summary
Fixes issue where users still appeared on leaderboards after losing all their roles.

## Problem
PR #78 fixed `User.currentHatIds` being updated when eligibility changes, but users with empty `currentHatIds` still had `membershipStatus: "Active"` and appeared on member lists/leaderboards.

## Fix
Updates `recordUserHatChange()` in utils.ts to also sync `membershipStatus`:
- When removing a hat results in empty `currentHatIds` → set `membershipStatus = "Inactive"`
- When adding a hat to an inactive user → set `membershipStatus = "Active"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)