### PR TITLE
Fix proposal metadata linking - follow task-manager pattern

### DIFF
--- a/pop-subgraph/src/direct-democracy-voting.ts
+++ b/pop-subgraph/src/direct-democracy-voting.ts
@@ -307,6 +307,13 @@ export function handleNewProposal(event: NewProposal): void {
   proposal.createdAtBlock = event.block.number;
   proposal.transactionHash = event.transaction.hash;
 
+  // Pre-set metadata link before saving (following task-manager and org-registry pattern)
+  // This ensures the relationship exists even before IPFS content is fetched
+  if (!event.params.descriptionHash.equals(ZERO_HASH)) {
+    let metadataCid = bytes32ToCid(event.params.descriptionHash);
+    proposal.metadata = metadataCid;
+  }
+
   proposal.save();
 
   // Trigger IPFS fetch for proposal metadata (description and option names)
@@ -335,6 +342,13 @@ export function handleNewHatProposal(event: NewHatProposal): void {
   proposal.status = "Active";
   proposal.createdAtBlock = event.block.number;
   proposal.transactionHash = event.transaction.hash;
+
+  // Pre-set metadata link before saving (following task-manager and org-registry pattern)
+  // This ensures the relationship exists even before IPFS content is fetched
+  if (!event.params.descriptionHash.equals(ZERO_HASH)) {
+    let metadataCid = bytes32ToCid(event.params.descriptionHash);
+    proposal.metadata = metadataCid;
+  }
 
   proposal.save();
 

--- a/pop-subgraph/src/hybrid-voting.ts
+++ b/pop-subgraph/src/hybrid-voting.ts
@@ -298,6 +298,13 @@ export function handleNewProposal(event: NewProposal): void {
   proposal.createdAtBlock = event.block.number;
   proposal.transactionHash = event.transaction.hash;
 
+  // Pre-set metadata link before saving (following task-manager and org-registry pattern)
+  // This ensures the relationship exists even before IPFS content is fetched
+  if (!event.params.descriptionHash.equals(ZERO_HASH)) {
+    let metadataCid = bytes32ToCid(event.params.descriptionHash);
+    proposal.metadata = metadataCid;
+  }
+
   proposal.save();
 
   // Trigger IPFS fetch for proposal metadata (description and option names)
@@ -345,6 +352,13 @@ export function handleNewHatProposal(event: NewHatProposal): void {
   proposal.wasExecuted = false;
   proposal.createdAtBlock = event.block.number;
   proposal.transactionHash = event.transaction.hash;
+
+  // Pre-set metadata link before saving (following task-manager and org-registry pattern)
+  // This ensures the relationship exists even before IPFS content is fetched
+  if (!event.params.descriptionHash.equals(ZERO_HASH)) {
+    let metadataCid = bytes32ToCid(event.params.descriptionHash);
+    proposal.metadata = metadataCid;
+  }
 
   proposal.save();
 


### PR DESCRIPTION
## Problem
Proposal metadata (description, option names) wasn't being linked to proposals even though IPFS content was uploaded correctly.

## Root Cause
The proposal event handlers weren't pre-setting `proposal.metadata` before saving, unlike the working patterns in `task-manager.ts` and `org-registry.ts` which do:
```typescript
let metadataCid = bytes32ToCid(metadataHash);
entity.metadata = metadataCid;  // Pre-set link
entity.save();
createMetadataSource(...);  // Then trigger IPFS fetch
```

## Fix
- Update `handleNewProposal` and `handleNewHatProposal` in both `hybrid-voting.ts` and `direct-democracy-voting.ts` to pre-set `proposal.metadata` before saving
- Simplify `proposal-metadata.ts` to only create the ProposalMetadata entity (removed redundant `linkMetadataToProposal`)

## Test
After deploying, create a new proposal and verify:
1. `proposal.metadata` is set immediately (even before IPFS is fetched)
2. ProposalMetadata entity is populated with description and optionNames

🤖 Generated with [Claude Code](https://claude.com/claude-code)