### PR TITLE
feat: Add project metadata indexing from IPFS

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -129,6 +129,7 @@ type Project @entity(immutable: false) {
   taskManager: TaskManager! # Relationship to TaskManager entity
   title: String! # project title
   metadataHash: Bytes! # project metadata hash
+  metadata: ProjectMetadata # Link to indexed metadata from IPFS
   cap: BigInt!
   createdAt: BigInt!
   createdAtBlock: BigInt!
@@ -140,6 +141,17 @@ type Project @entity(immutable: false) {
   rolePermissions: [ProjectRolePermission!]! @derivedFrom(field: "project")
   bountyCaps: [ProjectBountyCap!]! @derivedFrom(field: "project")
   capChanges: [ProjectCapChange!]! @derivedFrom(field: "project")
+}
+
+"""
+Project metadata fetched from IPFS.
+Contains project description.
+"""
+type ProjectMetadata @entity(immutable: false) {
+  id: String! # IPFS CID (Qm...)
+  project: Project
+  description: String # Project description from IPFS JSON
+  indexedAt: BigInt
 }
 
 # ========================================

--- a/pop-subgraph/src/project-metadata.ts
+++ b/pop-subgraph/src/project-metadata.ts
@@ -1,0 +1,46 @@
+import { Bytes, dataSource, json, BigInt, JSONValueKind } from "@graphprotocol/graph-ts";
+import { ProjectMetadata, Project } from "../generated/schema";
+
+/**
+ * Handler for IPFS file data source that parses project metadata JSON.
+ *
+ * Creates a ProjectMetadata entity with parsed fields from the IPFS JSON content.
+ * The Project entity links are pre-set by the event handlers (handleProjectCreated),
+ * so this handler only needs to populate the metadata.
+ */
+export function handleProjectMetadata(content: Bytes): void {
+  let ipfsHash = dataSource.stringParam();
+  let context = dataSource.context();
+  let projectId = context.getString("projectId");
+
+  // Load or create the ProjectMetadata entity using the IPFS hash as ID
+  let metadata = ProjectMetadata.load(ipfsHash);
+  if (metadata == null) {
+    metadata = new ProjectMetadata(ipfsHash);
+    metadata.project = projectId;
+    metadata.indexedAt = BigInt.fromI32(0);
+  }
+
+  // Try to parse the JSON content
+  let jsonResult = json.try_fromBytes(content);
+  if (jsonResult.isError) {
+    metadata.save();
+    return;
+  }
+
+  let jsonValue = jsonResult.value;
+  if (jsonValue.isNull() || jsonValue.kind != JSONValueKind.OBJECT) {
+    metadata.save();
+    return;
+  }
+
+  let jsonObject = jsonValue.toObject();
+
+  // Parse description
+  let descriptionValue = jsonObject.get("description");
+  if (descriptionValue != null && !descriptionValue.isNull() && descriptionValue.kind == JSONValueKind.STRING) {
+    metadata.description = descriptionValue.toString();
+  }
+
+  metadata.save();
+}

--- a/pop-subgraph/subgraph.yaml
+++ b/pop-subgraph/subgraph.yaml
@@ -815,6 +815,21 @@ templates:
       abis:
         - name: TaskManager
           file: ./abis/TaskManager.json
+  # IPFS file data source for project metadata
+  - kind: file/ipfs
+    name: ProjectMetadata
+    network: hoodi
+    mapping:
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      file: ./src/project-metadata.ts
+      handler: handleProjectMetadata
+      entities:
+        - ProjectMetadata
+        - Project
+      abis:
+        - name: TaskManager
+          file: ./abis/TaskManager.json
   # IPFS file data source for proposal metadata
   - kind: file/ipfs
     name: ProposalMetadata


### PR DESCRIPTION
## Summary
- Add `ProjectMetadata` entity to schema with `description` field
- Add `metadata` link field to `Project` entity  
- Create `project-metadata.ts` IPFS handler to parse project metadata JSON
- Add `ProjectMetadata` IPFS file data source in `subgraph.yaml`
- Update `handleProjectCreated` to set metadata link and trigger IPFS indexing

This follows the exact same pattern used for task metadata indexing, allowing project descriptions to be queried directly via GraphQL instead of requiring client-side IPFS fetching.

## Test plan
- [ ] Deploy subgraph to studio
- [ ] Create a new project with a description
- [ ] Query the project and verify `metadata.description` is populated

🤖 Generated with Claude Code