### PR TITLE
Fix indexing error in IPFS metadata handlers

### DIFF
--- a/pop-subgraph/src/org-metadata.ts
+++ b/pop-subgraph/src/org-metadata.ts
@@ -27,10 +27,13 @@ export function handleOrgMetadata(content: Bytes): void {
   // Try to parse the JSON content
   let jsonResult = json.try_fromBytes(content);
   if (jsonResult.isError) {
-    // JSON parsing failed - create entity with just the ID and org link
-    let metadata = new OrgMetadata(ipfsHash);
-    metadata.organization = orgId;
-    metadata.save();
+    // JSON parsing failed - load or create entity with just the ID and org link
+    let metadata = OrgMetadata.load(ipfsHash);
+    if (metadata == null) {
+      metadata = new OrgMetadata(ipfsHash);
+      metadata.organization = orgId;
+      metadata.save();
+    }
     return;
   }
 
@@ -95,9 +98,12 @@ export function handleOrgMetadata(content: Bytes): void {
       }
     }
   } else {
-    // Not a JSON object - create entity with just the ID and org link
-    let metadata = new OrgMetadata(ipfsHash);
-    metadata.organization = orgId;
-    metadata.save();
+    // Not a JSON object - load or create entity with just the ID and org link
+    let metadata = OrgMetadata.load(ipfsHash);
+    if (metadata == null) {
+      metadata = new OrgMetadata(ipfsHash);
+      metadata.organization = orgId;
+      metadata.save();
+    }
   }
 }

--- a/pop-subgraph/src/proposal-metadata.ts
+++ b/pop-subgraph/src/proposal-metadata.ts
@@ -40,11 +40,14 @@ export function handleProposalMetadata(content: Bytes): void {
   let jsonResult = json.try_fromBytes(content);
   if (jsonResult.isError) {
     log.warning("[ProposalMetadata] Failed to parse JSON for CID: {}", [ipfsCid]);
-    // Create entity with defaults so the relationship still works
-    let metadata = new ProposalMetadata(ipfsCid);
-    metadata.description = "";
-    metadata.optionNames = [];
-    metadata.save();
+    // Load or create entity with defaults so the relationship still works
+    let metadata = ProposalMetadata.load(ipfsCid);
+    if (metadata == null) {
+      metadata = new ProposalMetadata(ipfsCid);
+      metadata.description = "";
+      metadata.optionNames = [];
+      metadata.save();
+    }
     return;
   }
 
@@ -52,8 +55,11 @@ export function handleProposalMetadata(content: Bytes): void {
   if (!jsonValue.isNull() && jsonValue.kind == JSONValueKind.OBJECT) {
     let jsonObject = jsonValue.toObject();
 
-    // Create the metadata entity
-    let metadata = new ProposalMetadata(ipfsCid);
+    // Load or create the metadata entity
+    let metadata = ProposalMetadata.load(ipfsCid);
+    if (metadata == null) {
+      metadata = new ProposalMetadata(ipfsCid);
+    }
 
     // Parse description
     let descriptionValue = jsonObject.get("description");
@@ -95,11 +101,14 @@ export function handleProposalMetadata(content: Bytes): void {
       ipfsCid
     ]);
   } else {
-    // Not a JSON object - create entity with defaults
+    // Not a JSON object - load or create entity with defaults
     log.warning("[ProposalMetadata] Content is not a JSON object for CID: {}", [ipfsCid]);
-    let metadata = new ProposalMetadata(ipfsCid);
-    metadata.description = "";
-    metadata.optionNames = [];
-    metadata.save();
+    let metadata = ProposalMetadata.load(ipfsCid);
+    if (metadata == null) {
+      metadata = new ProposalMetadata(ipfsCid);
+      metadata.description = "";
+      metadata.optionNames = [];
+      metadata.save();
+    }
   }
 }


### PR DESCRIPTION
## Summary
Fix "Failed to transact block operations" error by preventing entity creation conflicts in IPFS metadata handlers. Add load checks before creating entities to handle duplicate IPFS requests gracefully.

## Changes
- `proposal-metadata.ts`: Add `ProposalMetadata.load()` check before entity creation in 3 locations
- `org-metadata.ts`: Add `OrgMetadata.load()` check before entity creation in 2 locations

## Testing
- All 184 Matchstick tests pass
- Subgraph builds successfully
- Linter reports no issues

🤖 Generated with Claude Code