### PR TITLE
Fix immutable entity update errors in IPFS handlers

### DIFF
--- a/pop-subgraph/src/org-metadata.ts
+++ b/pop-subgraph/src/org-metadata.ts
@@ -41,11 +41,14 @@ export function handleOrgMetadata(content: Bytes): void {
   if (!jsonValue.isNull() && jsonValue.kind == JSONValueKind.OBJECT) {
     let jsonObject = jsonValue.toObject();
 
-    // Create or load the metadata entity
-    let metadata = OrgMetadata.load(ipfsHash);
-    if (metadata == null) {
-      metadata = new OrgMetadata(ipfsHash);
+    // Check if metadata already exists - if so, skip to avoid re-creating immutable OrgMetadataLink entities
+    let existingMetadata = OrgMetadata.load(ipfsHash);
+    if (existingMetadata != null) {
+      return;
     }
+
+    // Create new metadata entity
+    let metadata = new OrgMetadata(ipfsHash);
 
     // Link to organization
     metadata.organization = orgId;
@@ -68,7 +71,7 @@ export function handleOrgMetadata(content: Bytes): void {
 
     metadata.save();
 
-    // Parse links array
+    // Parse links array - OrgMetadataLink is immutable so only create once
     let linksValue = jsonObject.get("links");
     if (linksValue != null && !linksValue.isNull() && linksValue.kind == JSONValueKind.ARRAY) {
       let linksArray = linksValue.toArray();

--- a/pop-subgraph/src/proposal-metadata.ts
+++ b/pop-subgraph/src/proposal-metadata.ts
@@ -55,11 +55,15 @@ export function handleProposalMetadata(content: Bytes): void {
   if (!jsonValue.isNull() && jsonValue.kind == JSONValueKind.OBJECT) {
     let jsonObject = jsonValue.toObject();
 
-    // Load or create the metadata entity
-    let metadata = ProposalMetadata.load(ipfsCid);
-    if (metadata == null) {
-      metadata = new ProposalMetadata(ipfsCid);
+    // ProposalMetadata is immutable - if it already exists, skip processing
+    let existingMetadata = ProposalMetadata.load(ipfsCid);
+    if (existingMetadata != null) {
+      log.info("[ProposalMetadata] Entity already exists for CID: {}, skipping (immutable)", [ipfsCid]);
+      return;
     }
+
+    // Create new metadata entity
+    let metadata = new ProposalMetadata(ipfsCid);
 
     // Parse description
     let descriptionValue = jsonObject.get("description");


### PR DESCRIPTION
## Summary
Fix "Failed to transact block operations" error caused by attempting to update immutable entities when IPFS content is processed multiple times.

## Root Cause
- `ProposalMetadata` is marked `@entity(immutable: true)` in the schema
- `OrgMetadataLink` is also immutable
- When IPFS retries or duplicate events occur, the handlers were loading existing entities, modifying fields, and calling `.save()` - which fails for immutable entities

## Changes
- `proposal-metadata.ts`: Return early if ProposalMetadata already exists
- `org-metadata.ts`: Return early if OrgMetadata exists to avoid re-creating immutable OrgMetadataLink entities

🤖 Generated with Claude Code