### PR TITLE
Fix UserHatChange ID collision in bulk eligibility updates

### DIFF
--- a/pop-subgraph/src/utils.ts
+++ b/pop-subgraph/src/utils.ts
@@ -237,7 +237,13 @@ export function recordUserHatChange(
   added: boolean,
   event: ethereum.Event
 ): UserHatChange {
-  let id = event.transaction.hash.concatI32(event.logIndex.toI32());
+  // Include user.id AND hatId in the ID to ensure uniqueness when:
+  // - Bulk events update multiple users (same hatId, different users)
+  // - Single user receives multiple hats (same user, different hatIds)
+  // UserHatChange is immutable, so duplicate IDs would cause "Failed to transact block operations"
+  let id = event.transaction.hash.concatI32(event.logIndex.toI32())
+    .concat(Bytes.fromUTF8(user.id))
+    .concat(Bytes.fromByteArray(Bytes.fromBigInt(hatId)));
   let hatChange = new UserHatChange(id);
   hatChange.user = user.id;
   hatChange.hatId = hatId;


### PR DESCRIPTION
## Summary
Fix "Failed to transact block operations" error when bulk operations process multiple users/hats in one event.

## Root Cause
`recordUserHatChange()` creates immutable `UserHatChange` entities with ID = `txHash + logIndex`. This caused collisions in:

1. **BulkWearerEligibilityUpdated**: Multiple users affected in one event (same hatId, different users)
2. **handleQuickJoined**: Single user receives multiple hats (same user, different hatIds)
3. **handleHatsMinted**: Single user minted multiple hats (same user, different hatIds)

Triggered by ClawDAO v2 proposal executions "Revoke Shuri 10min" and "Remove Hudson 10min".

## Fix
Include both `user.id` AND `hatId` in the `UserHatChange` entity ID to ensure uniqueness across all scenarios:
```typescript
let id = event.transaction.hash.concatI32(event.logIndex.toI32())
  .concat(Bytes.fromUTF8(user.id))
  .concat(Bytes.fromByteArray(Bytes.fromBigInt(hatId)));
```

🤖 Generated with Claude Code