### PR TITLE
Fix: Handle missing IPFS content gracefully

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -1657,11 +1657,13 @@ type HatMetadata @entity(immutable: false) {
 IPFS-indexed proposal metadata content.
 This entity is populated by a file data source that fetches from IPFS.
 Contains the proposal description and option names that were uploaded when creating the proposal.
+A stub entity with defaults is created immediately when the proposal is created, then updated
+when IPFS content is fetched. This ensures the entity exists even if IPFS is unavailable.
 """
-type ProposalMetadata @entity(immutable: true) {
+type ProposalMetadata @entity(immutable: false) {
   id: String! # IPFS CID (Qm...)
-  description: String! # Full proposal description text
-  optionNames: [String!]! # Names for each voting option
+  description: String! # Full proposal description text (empty if IPFS unavailable)
+  optionNames: [String!]! # Names for each voting option (empty if IPFS unavailable)
   createdAt: BigInt # Timestamp from IPFS metadata
 }
 

--- a/pop-subgraph/src/direct-democracy-voting.ts
+++ b/pop-subgraph/src/direct-democracy-voting.ts
@@ -19,7 +19,8 @@ import {
   DirectDemocracyVotingQuorumChange,
   HatPermission,
   DDVProposal,
-  DDVVote
+  DDVVote,
+  ProposalMetadata
 } from "../generated/schema";
 import { ProposalMetadata as ProposalMetadataTemplate } from "../generated/templates";
 import { getUsernameForAddress, loadExistingUser, createExecutorChange, getOrCreateRole } from "./utils";
@@ -307,11 +308,19 @@ export function handleNewProposal(event: NewProposal): void {
   proposal.createdAtBlock = event.block.number;
   proposal.transactionHash = event.transaction.hash;
 
-  // Pre-set metadata link before saving (following task-manager and org-registry pattern)
-  // This ensures the relationship exists even before IPFS content is fetched
+  // Create stub ProposalMetadata immediately to ensure entity exists even if IPFS fails
   if (!event.params.descriptionHash.equals(ZERO_HASH)) {
     let metadataCid = bytes32ToCid(event.params.descriptionHash);
     proposal.metadata = metadataCid;
+
+    // Create stub metadata entity with defaults - will be updated by IPFS handler if content exists
+    let metadata = ProposalMetadata.load(metadataCid);
+    if (metadata == null) {
+      metadata = new ProposalMetadata(metadataCid);
+      metadata.description = "";
+      metadata.optionNames = [];
+      metadata.save();
+    }
   }
 
   proposal.save();
@@ -343,11 +352,19 @@ export function handleNewHatProposal(event: NewHatProposal): void {
   proposal.createdAtBlock = event.block.number;
   proposal.transactionHash = event.transaction.hash;
 
-  // Pre-set metadata link before saving (following task-manager and org-registry pattern)
-  // This ensures the relationship exists even before IPFS content is fetched
+  // Create stub ProposalMetadata immediately to ensure entity exists even if IPFS fails
   if (!event.params.descriptionHash.equals(ZERO_HASH)) {
     let metadataCid = bytes32ToCid(event.params.descriptionHash);
     proposal.metadata = metadataCid;
+
+    // Create stub metadata entity with defaults - will be updated by IPFS handler if content exists
+    let metadata = ProposalMetadata.load(metadataCid);
+    if (metadata == null) {
+      metadata = new ProposalMetadata(metadataCid);
+      metadata.description = "";
+      metadata.optionNames = [];
+      metadata.save();
+    }
   }
 
   proposal.save();

--- a/pop-subgraph/src/proposal-metadata.ts
+++ b/pop-subgraph/src/proposal-metadata.ts
@@ -55,15 +55,11 @@ export function handleProposalMetadata(content: Bytes): void {
   if (!jsonValue.isNull() && jsonValue.kind == JSONValueKind.OBJECT) {
     let jsonObject = jsonValue.toObject();
 
-    // ProposalMetadata is immutable - if it already exists, skip processing
-    let existingMetadata = ProposalMetadata.load(ipfsCid);
-    if (existingMetadata != null) {
-      log.info("[ProposalMetadata] Entity already exists for CID: {}, skipping (immutable)", [ipfsCid]);
-      return;
+    // Load existing stub (created by proposal handler) or create new entity
+    let metadata = ProposalMetadata.load(ipfsCid);
+    if (metadata == null) {
+      metadata = new ProposalMetadata(ipfsCid);
     }
-
-    // Create new metadata entity
-    let metadata = new ProposalMetadata(ipfsCid);
 
     // Parse description
     let descriptionValue = jsonObject.get("description");


### PR DESCRIPTION
## Summary
- Creates stub ProposalMetadata entities immediately when proposals are created
- Changed ProposalMetadata from immutable to mutable so stubs can be updated
- IPFS handler updates existing stubs instead of creating new entities
- Prevents dangling references and "Failed to transact block operations" errors

## Problem
When IPFS content doesn't exist (404 errors), the file handler never runs and ProposalMetadata entities are never created. This left Proposal.metadata pointing to non-existent entities.

## Test plan
- [x] All 184 tests pass
- [x] subgraph-lint passes
- [x] npm run build succeeds
- [ ] Redeploy and verify proposals with missing IPFS content don't crash the subgraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)