### PR TITLE
Fix: Remove metadata stub pattern causing causality region conflicts

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -1657,13 +1657,13 @@ type HatMetadata @entity(immutable: false) {
 IPFS-indexed proposal metadata content.
 This entity is populated by a file data source that fetches from IPFS.
 Contains the proposal description and option names that were uploaded when creating the proposal.
-A stub entity with defaults is created immediately when the proposal is created, then updated
-when IPFS content is fetched. This ensures the entity exists even if IPFS is unavailable.
+If IPFS content is unavailable (404), this entity won't be created and the proposal.metadata
+reference will point to a non-existent entity (queries will return null).
 """
-type ProposalMetadata @entity(immutable: false) {
+type ProposalMetadata @entity(immutable: true) {
   id: String! # IPFS CID (Qm...)
-  description: String! # Full proposal description text (empty if IPFS unavailable)
-  optionNames: [String!]! # Names for each voting option (empty if IPFS unavailable)
+  description: String! # Full proposal description text
+  optionNames: [String!]! # Names for each voting option
   createdAt: BigInt # Timestamp from IPFS metadata
 }
 

--- a/pop-subgraph/src/direct-democracy-voting.ts
+++ b/pop-subgraph/src/direct-democracy-voting.ts
@@ -19,8 +19,7 @@ import {
   DirectDemocracyVotingQuorumChange,
   HatPermission,
   DDVProposal,
-  DDVVote,
-  ProposalMetadata
+  DDVVote
 } from "../generated/schema";
 import { ProposalMetadata as ProposalMetadataTemplate } from "../generated/templates";
 import { getUsernameForAddress, loadExistingUser, createExecutorChange, getOrCreateRole } from "./utils";
@@ -308,19 +307,10 @@ export function handleNewProposal(event: NewProposal): void {
   proposal.createdAtBlock = event.block.number;
   proposal.transactionHash = event.transaction.hash;
 
-  // Create stub ProposalMetadata immediately to ensure entity exists even if IPFS fails
+  // Set metadata link - entity will be created by IPFS handler if content exists
   if (!event.params.descriptionHash.equals(ZERO_HASH)) {
     let metadataCid = bytes32ToCid(event.params.descriptionHash);
     proposal.metadata = metadataCid;
-
-    // Create stub metadata entity with defaults - will be updated by IPFS handler if content exists
-    let metadata = ProposalMetadata.load(metadataCid);
-    if (metadata == null) {
-      metadata = new ProposalMetadata(metadataCid);
-      metadata.description = "";
-      metadata.optionNames = [];
-      metadata.save();
-    }
   }
 
   proposal.save();
@@ -352,19 +342,10 @@ export function handleNewHatProposal(event: NewHatProposal): void {
   proposal.createdAtBlock = event.block.number;
   proposal.transactionHash = event.transaction.hash;
 
-  // Create stub ProposalMetadata immediately to ensure entity exists even if IPFS fails
+  // Set metadata link - entity will be created by IPFS handler if content exists
   if (!event.params.descriptionHash.equals(ZERO_HASH)) {
     let metadataCid = bytes32ToCid(event.params.descriptionHash);
     proposal.metadata = metadataCid;
-
-    // Create stub metadata entity with defaults - will be updated by IPFS handler if content exists
-    let metadata = ProposalMetadata.load(metadataCid);
-    if (metadata == null) {
-      metadata = new ProposalMetadata(metadataCid);
-      metadata.description = "";
-      metadata.optionNames = [];
-      metadata.save();
-    }
   }
 
   proposal.save();

--- a/pop-subgraph/src/proposal-metadata.ts
+++ b/pop-subgraph/src/proposal-metadata.ts
@@ -55,11 +55,15 @@ export function handleProposalMetadata(content: Bytes): void {
   if (!jsonValue.isNull() && jsonValue.kind == JSONValueKind.OBJECT) {
     let jsonObject = jsonValue.toObject();
 
-    // Load existing stub (created by proposal handler) or create new entity
-    let metadata = ProposalMetadata.load(ipfsCid);
-    if (metadata == null) {
-      metadata = new ProposalMetadata(ipfsCid);
+    // ProposalMetadata is immutable - skip if already exists
+    let existingMetadata = ProposalMetadata.load(ipfsCid);
+    if (existingMetadata != null) {
+      log.info("[ProposalMetadata] Entity already exists for CID: {}, skipping (immutable)", [ipfsCid]);
+      return;
     }
+
+    // Create new metadata entity
+    let metadata = new ProposalMetadata(ipfsCid);
 
     // Parse description
     let descriptionValue = jsonObject.get("description");


### PR DESCRIPTION
## Summary
Reverts the stub pattern introduced in PR #89 which caused causality region conflicts in The Graph.

## Problem
When an event handler creates a metadata stub AND creates a file data source in the same block, both operations run in separate causality regions (cr=0 vs cr=1). Both try to Insert the same entity, causing:
```
can not append operations that go backwards from Insert {...cr=0} to Insert {...cr=1}
```

## Solution
- Remove stub creation from task/proposal event handlers
- Let IPFS handlers be the sole creators of metadata entities
- If IPFS content doesn't exist (404), the entity simply won't be created
- Queries will return null for metadata in those cases

## Changes
- Revert ProposalMetadata to immutable
- Remove ProposalMetadata stub creation from hybrid-voting.ts and direct-democracy-voting.ts
- Remove TaskMetadata stub creation from task-manager.ts

## Test plan
- [x] npm run build succeeds
- [x] subgraph-lint passes
- [ ] Redeploy and verify no causality region conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)