### PR TITLE
Fix: Skip duplicate file data sources to prevent causality conflicts

### DIFF
--- a/pop-subgraph/src/direct-democracy-voting.ts
+++ b/pop-subgraph/src/direct-democracy-voting.ts
@@ -19,7 +19,8 @@ import {
   DirectDemocracyVotingQuorumChange,
   HatPermission,
   DDVProposal,
-  DDVVote
+  DDVVote,
+  ProposalMetadata
 } from "../generated/schema";
 import { ProposalMetadata as ProposalMetadataTemplate } from "../generated/templates";
 import { getUsernameForAddress, loadExistingUser, createExecutorChange, getOrCreateRole } from "./utils";
@@ -54,6 +55,12 @@ function createProposalMetadataDataSource(descriptionHash: Bytes, proposalEntity
 
   // Convert bytes32 to IPFS CIDv0
   let ipfsCid = bytes32ToCid(descriptionHash);
+
+  // Skip if ProposalMetadata already exists - prevents duplicate file data sources
+  let existingMetadata = ProposalMetadata.load(ipfsCid);
+  if (existingMetadata != null) {
+    return;
+  }
 
   // Create context to pass proposal info to the IPFS handler
   let context = new DataSourceContext();

--- a/pop-subgraph/src/hybrid-voting.ts
+++ b/pop-subgraph/src/hybrid-voting.ts
@@ -21,7 +21,8 @@ import {
   Proposal,
   Vote,
   VotingClass,
-  VotingClassChange
+  VotingClassChange,
+  ProposalMetadata
 } from "../generated/schema";
 import { ProposalMetadata as ProposalMetadataTemplate } from "../generated/templates";
 import { getUsernameForAddress, loadExistingUser, createHatPermission, createExecutorChange, getOrCreateRole } from "./utils";
@@ -56,6 +57,12 @@ function createProposalMetadataDataSource(descriptionHash: Bytes, proposalEntity
 
   // Convert bytes32 to IPFS CIDv0
   let ipfsCid = bytes32ToCid(descriptionHash);
+
+  // Skip if ProposalMetadata already exists - prevents duplicate file data sources
+  let existingMetadata = ProposalMetadata.load(ipfsCid);
+  if (existingMetadata != null) {
+    return;
+  }
 
   // Create context to pass proposal info to the IPFS handler
   let context = new DataSourceContext();

--- a/pop-subgraph/src/task-manager.ts
+++ b/pop-subgraph/src/task-manager.ts
@@ -26,7 +26,9 @@ import {
   ProjectRolePermission,
   ProjectBountyCap,
   ProjectCapChange,
-  BountyCapChange
+  BountyCapChange,
+  TaskMetadata,
+  ProjectMetadata
 } from "../generated/schema";
 import { getUsernameForAddress, loadExistingUser } from "./utils";
 
@@ -113,6 +115,14 @@ function createTaskMetadataSource(metadataHash: Bytes, taskId: string, metadataT
   // Convert bytes32 sha256 digest to IPFS CIDv0 string
   let ipfsCid = bytes32ToCid(metadataHash);
 
+  // Skip if TaskMetadata already exists - prevents duplicate file data sources
+  // which can cause causality region conflicts when multiple sources for the
+  // same CID try to create the same entity
+  let existingMetadata = TaskMetadata.load(ipfsCid);
+  if (existingMetadata != null) {
+    return;
+  }
+
   // Create context to pass taskId and type to the IPFS handler
   let context = new DataSourceContext();
   context.setString("taskId", taskId);
@@ -136,6 +146,12 @@ function createProjectMetadataSource(metadataHash: Bytes, projectId: string): vo
 
   // Convert bytes32 sha256 digest to IPFS CIDv0 string
   let ipfsCid = bytes32ToCid(metadataHash);
+
+  // Skip if ProjectMetadata already exists - prevents duplicate file data sources
+  let existingMetadata = ProjectMetadata.load(ipfsCid);
+  if (existingMetadata != null) {
+    return;
+  }
 
   // Create context to pass projectId to the IPFS handler
   let context = new DataSourceContext();


### PR DESCRIPTION
## Summary
Fixes the duplicate key constraint error when multiple events create file data sources for the same IPFS CID.

## Problem
When multiple tasks/proposals reference the same IPFS CID, or when events fire multiple times for the same content:
```
duplicate key value violates unique constraint "task_metadata_pkey": Key (vid)=(...) already exists
```

This happens because multiple file data source handlers run in parallel for the same CID and all try to Insert the same entity.

## Solution
Before creating a file data source, check if the metadata entity already exists. If it does, skip creating the file data source entirely.

## Changes
- task-manager.ts: Check TaskMetadata/ProjectMetadata existence before creating file data sources
- hybrid-voting.ts: Check ProposalMetadata existence before creating file data sources  
- direct-democracy-voting.ts: Check ProposalMetadata existence before creating file data sources

## Test plan
- [x] npm run build succeeds
- [x] subgraph-lint passes
- [ ] Redeploy and verify no duplicate key errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)