### PR TITLE
Fix: Use unique task-specific IDs for TaskMetadata entities

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -296,8 +296,9 @@ Contains task description, difficulty, estimated hours, and submission content.
 The entity ID changes to the submission hash when a task is submitted.
 """
 type TaskMetadata @entity(immutable: false) {
-  id: String! # IPFS CID (Qm...) - changes to submission CID when task is submitted
+  id: String! # taskId-ipfsCID format (e.g. "0x123-456-QmAbc...") - unique per task
   task: Task
+  ipfsCid: String # The IPFS CID (Qm...) for reference
   name: String # Task name from IPFS JSON
   description: String # Task description from IPFS JSON
   location: String # Task location/status from IPFS JSON

--- a/pop-subgraph/src/task-metadata.ts
+++ b/pop-subgraph/src/task-metadata.ts
@@ -9,15 +9,20 @@ import { TaskMetadata, Task } from "../generated/schema";
  * and handleTaskSubmitted), so this handler only needs to populate the metadata.
  */
 export function handleTaskMetadata(content: Bytes): void {
-  let ipfsHash = dataSource.stringParam();
+  let ipfsCid = dataSource.stringParam();
   let context = dataSource.context();
   let taskId = context.getString("taskId");
 
-  // Load or create the TaskMetadata entity using the IPFS hash as ID
-  let metadata = TaskMetadata.load(ipfsHash);
+  // Use taskId-ipfsCID as the entity ID to ensure uniqueness per task
+  // This prevents collisions when multiple tasks share the same metadata CID
+  let entityId = taskId + "-" + ipfsCid;
+
+  // Load or create the TaskMetadata entity
+  let metadata = TaskMetadata.load(entityId);
   if (metadata == null) {
-    metadata = new TaskMetadata(ipfsHash);
+    metadata = new TaskMetadata(entityId);
     metadata.task = taskId;
+    metadata.ipfsCid = ipfsCid;
     metadata.indexedAt = BigInt.fromI32(0);
   }
 


### PR DESCRIPTION
## Summary
- Changed TaskMetadata entity ID from just IPFS CID (`Qm...`) to `taskId-ipfsCID` format to prevent duplicate key constraint violations
- Added `ipfsCid` field to TaskMetadata schema to preserve the raw CID for reference
- Updated all metadata link references in task-manager.ts handlers (TaskCreated, TaskSubmitted, TaskUpdated)

## Test plan
- [x] `npm run codegen` passes
- [x] `npm run build` passes
- [x] `npm run test` passes (184 tests)
- [x] `subgraph-lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)