### PR TITLE
Fix: Add IPFSFileRequest tracker to prevent duplicate file data sources

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -292,6 +292,16 @@ type Task @entity(immutable: false) {
 }
 
 """
+Tracks IPFS file data source requests to prevent duplicate creation.
+Created in the main handler before calling Template.create() to ensure
+only one file data source is created per CID, even when multiple events
+in the same block reference the same IPFS content.
+"""
+type IPFSFileRequest @entity(immutable: true) {
+  id: String! # IPFS CID (Qm...)
+}
+
+"""
 Task metadata fetched from IPFS.
 Contains task description, difficulty, estimated hours, and submission content.
 Uses IPFS CID as ID - multiple tasks can share the same metadata if they have the same content hash.


### PR DESCRIPTION
## Summary
Adds `IPFSFileRequest` tracker entity to prevent duplicate file data source creation when multiple events in the same block reference the same IPFS CID.

The previous fix (PR #94) checked if `TaskMetadata` existed before creating file data sources, but that check runs in the main handler **before** file data sources execute. When multiple events in the same block share the same CID, all pass the check because the file handler hasn't run yet.

This fix creates a tracker entity **immediately** in the main handler before calling `Template.create()`, so subsequent handlers in the same block see it and skip.

## Test Plan
- ✅ All 184 tests passing
- ✅ Build successful
- ✅ Linter passes

Generated with [Claude Code](https://claude.com/claude-code)