### PR TITLE
Make TaskMetadata IDs unique by including transaction hash

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -295,7 +295,7 @@ Task metadata fetched from IPFS.
 Contains task description, difficulty, estimated hours, and submission content.
 """
 type TaskMetadata @entity(immutable: false) {
-  id: String! # IPFS CID (Qm...)
+  id: String! # txHash-ipfsCid (e.g. 0xabc...-Qm...)
   task: Task # Link back to the task
   name: String # Task name from IPFS JSON
   description: String # Task description from IPFS JSON


### PR DESCRIPTION
## Summary
TaskMetadata entities are now keyed by `txHash-ipfsCid` instead of just the IPFS CID. This ensures uniqueness per transaction and prevents collisions when the same metadata hash appears in multiple transactions.

## Changes
- Updated TaskMetadata ID format to `txHash-ipfsCid` (e.g., `0xabc...-Qm...`)
- Pass transaction hash through DataSourceContext to IPFS handler
- Updated all callers (handleTaskCreated, handleTaskSubmitted, handleTaskUpdated) to pass tx hash
- Updated schema comment and entity deduplication logic

## Testing
Build completes successfully with all TypeScript compilation passing.

🤖 Generated with Claude Code