### PR TITLE
Fix: Use load-or-create pattern for Task and TaskApplication entities

### DIFF
--- a/pop-subgraph/src/task-manager.ts
+++ b/pop-subgraph/src/task-manager.ts
@@ -215,7 +215,10 @@ export function handleTaskCreated(event: TaskCreated): void {
   let taskManagerAddress = event.address.toHexString();
   let id = taskManagerAddress + "-" + taskId;
 
-  let task = new Task(id);
+  let task = Task.load(id);
+  if (task == null) {
+    task = new Task(id);
+  }
 
   task.taskId = event.params.id;
   task.taskManager = event.address;
@@ -418,7 +421,10 @@ export function handleTaskApplicationSubmitted(event: TaskApplicationSubmitted):
   let applicantAddress = event.params.applicant.toHexString();
   let id = taskManagerAddress + "-" + taskId + "-" + applicantAddress;
 
-  let application = new TaskApplication(id);
+  let application = TaskApplication.load(id);
+  if (application == null) {
+    application = new TaskApplication(id);
+  }
 
   application.task = taskEntityId;
   application.applicant = event.params.applicant;


### PR DESCRIPTION
## Summary
During reorg/reindexing, events may be replayed and attempting to insert entities with the same primary key caused constraint violations. This fix loads existing entities first before creating new ones.

## Changes
- `handleTaskCreated`: Load Task before creating to prevent duplicate key errors
- `handleTaskApplicationSubmitted`: Load TaskApplication before creating to prevent duplicate key errors

## Testing
All 184 Matchstick tests pass.

🤖 Generated with Claude Code