### PR TITLE
Fix: Use separate tracker entity to prevent TaskMetadata vid collision

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -291,6 +291,16 @@ type Task @entity(immutable: false) {
 }
 
 """
+Tracks IPFS file data source requests to prevent duplicate creation.
+Created in the onchain event handler before calling createWithContext().
+Must be MUTABLE — immutable entities hit the graph-node #6313 memoization
+bug where load() fails across batched blocks.
+"""
+type TaskMetadataRequest @entity(immutable: false) {
+  id: String! # IPFS CID (Qm...)
+}
+
+"""
 Task metadata fetched from IPFS.
 Contains task description, difficulty, estimated hours, and submission content.
 """


### PR DESCRIPTION
## Summary
- Replaces the TaskMetadata stub approach from #102 with a separate `TaskMetadataRequest` mutable tracker entity
- The stub approach caused "impossible combination of entity operations" errors because onchain writes (cr=0) and offchain IPFS handler writes (cr=1) for the same entity ID conflict across causality regions
- The tracker entity lives only in the onchain context and is a different entity type from `TaskMetadata`, so it never conflicts with the IPFS handler
- Switches TaskMetadata IDs to CID-only (matching OrgMetadata/HatMetadata pattern)

## Root cause
Two events referencing the same IPFS CID each call `createWithContext()`, spawning two file data source handlers. Each handler gets a fresh `EntityCache` with `vid_seq` starting at 100, computing identical `vid = (block_number << 32) + 100` — violating the primary key constraint.

## Test plan
- [x] `npm run codegen` passes
- [x] `npm run build` passes
- [x] All 184 Matchstick tests pass
- [ ] Deploy to hosted service and verify indexing completes without vid collision or causality region errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)