### PR TITLE
Revert task metadata to PR #98 state

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -291,21 +291,11 @@ type Task @entity(immutable: false) {
 }
 
 """
-Tracks IPFS file data source requests to prevent duplicate creation.
-Created in the onchain event handler before calling createWithContext().
-Must be MUTABLE — immutable entities hit the graph-node #6313 memoization
-bug where load() fails across batched blocks.
-"""
-type TaskMetadataRequest @entity(immutable: false) {
-  id: String! # IPFS CID (Qm...)
-}
-
-"""
 Task metadata fetched from IPFS.
 Contains task description, difficulty, estimated hours, and submission content.
 """
 type TaskMetadata @entity(immutable: false) {
-  id: String! # IPFS CID (Qm...)
+  id: String! # txHash-ipfsCid (e.g. 0xabc...-Qm...)
   task: Task # Link back to the task
   name: String # Task name from IPFS JSON
   description: String # Task description from IPFS JSON

--- a/pop-subgraph/src/task-metadata.ts
+++ b/pop-subgraph/src/task-metadata.ts
@@ -4,7 +4,7 @@ import { TaskMetadata } from "../generated/schema";
 /**
  * Handler for IPFS file data source that parses task metadata JSON.
  *
- * Creates a mutable TaskMetadata entity keyed by CID (matching OrgMetadata/HatMetadata pattern).
+ * Creates a mutable TaskMetadata entity keyed by txHash-CID for uniqueness.
  * Uses "load or create" pattern which is safe for mutable entities and
  * handles retries gracefully without triggering duplicate key constraint violations.
  */
@@ -13,11 +13,15 @@ export function handleTaskMetadata(content: Bytes): void {
   let context = dataSource.context();
   let taskId = context.getString("taskId");
   let timestamp = context.getBigInt("timestamp");
+  let txHash = context.getBytes("txHash");
+
+  // Entity ID includes tx hash for uniqueness
+  let entityId = txHash.toHexString() + "-" + ipfsCid;
 
   // Load or create metadata entity (mutable entity - safe to update)
-  let metadata = TaskMetadata.load(ipfsCid);
+  let metadata = TaskMetadata.load(entityId);
   if (metadata == null) {
-    metadata = new TaskMetadata(ipfsCid);
+    metadata = new TaskMetadata(entityId);
     metadata.task = taskId;
     metadata.indexedAt = timestamp;
   }


### PR DESCRIPTION
## Summary
- Reverts changes from #102 and #103 that attempted to fix the `task_metadata_pkey` vid collision
- Restores the codebase to exactly the PR #98 state

🤖 Generated with [Claude Code](https://claude.com/claude-code)