### PR TITLE
Add log statement to force new WASM CID for reindex

### DIFF
--- a/pop-subgraph/src/governance-factory.ts
+++ b/pop-subgraph/src/governance-factory.ts
@@ -1,7 +1,9 @@
+import { log } from "@graphprotocol/graph-ts";
 import { ModuleDeployed } from "../generated/GovernanceFactory/GovernanceFactory";
 import { GovernanceModule } from "../generated/schema";
 
 export function handleModuleDeployed(event: ModuleDeployed): void {
+  log.info("handleModuleDeployed v2", []);
   let module = new GovernanceModule(event.params.proxy);
 
   module.orgId = event.params.orgId;

--- a/pop-subgraph/subgraph.yaml
+++ b/pop-subgraph/subgraph.yaml
@@ -1,4 +1,3 @@
-# Redeploy trigger
 specVersion: 1.3.0
 indexerHints:
   prune: auto


### PR DESCRIPTION
## Summary
- Adds a `log.info` call in `governance-factory.ts` to change the compiled WASM output, producing a new subgraph CID and triggering a reindex.
- Reverts the no-op YAML comment from the previous attempt since comments don't affect the CID.

## Test plan
- [x] `npm run codegen` passes
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)