### PR TITLE
feat: Link TaskRejection to its TaskMetadata entity

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -334,6 +334,7 @@ type TaskRejection @entity(immutable: true) {
   rejectorUsername: String
   rejectorUser: User
   rejectionHash: Bytes! # IPFS hash of rejection reason
+  metadata: TaskMetadata # Link to rejection metadata from IPFS (contains rejection reason)
   rejectedAt: BigInt!
   rejectedAtBlock: BigInt!
   transactionHash: Bytes!

--- a/pop-subgraph/src/task-manager.ts
+++ b/pop-subgraph/src/task-manager.ts
@@ -642,6 +642,10 @@ export function handleTaskRejected(event: TaskRejected): void {
   rejection.rejector = event.params.rejector;
   rejection.rejectorUsername = getUsernameForAddress(event.params.rejector);
   rejection.rejectionHash = event.params.rejectionHash;
+
+  // Link to rejection metadata entity (will be created by IPFS data source)
+  let rejectionCid = bytes32ToCid(event.params.rejectionHash);
+  rejection.metadata = event.transaction.hash.toHexString() + "-" + rejectionCid;
   rejection.rejectedAt = event.block.timestamp;
   rejection.rejectedAtBlock = event.block.number;
   rejection.transactionHash = event.transaction.hash;


### PR DESCRIPTION
## Summary

When a task is rejected, `handleTaskRejected` creates a `TaskMetadata` entity from the rejection IPFS hash (via the data source template) but never links it to anything queryable. The `Task.metadata` pointer stays pointing at the submission metadata, making rejection reasons unreachable through the indexed query path.

## Changes

- **schema.graphql**: Add `metadata: TaskMetadata` field to `TaskRejection`
- **task-manager.ts**: Set `rejection.metadata` in `handleTaskRejected` using the same `txHash-CID` entity ID pattern used elsewhere

This enables querying rejection reasons via:
```graphql
rejections {
  metadata {
    rejection
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)