### PR TITLE
fix: Parse rejection reason from correct IPFS JSON key

### DIFF
--- a/pop-subgraph/src/task-metadata.ts
+++ b/pop-subgraph/src/task-metadata.ts
@@ -80,7 +80,8 @@ export function handleTaskMetadata(content: Bytes): void {
   }
 
   // Parse rejection reason (for rejection metadata entities)
-  let rejectionValue = jsonObject.get("rejection");
+  // The frontend uploads rejection metadata with key "rejectionReason"
+  let rejectionValue = jsonObject.get("rejectionReason");
   if (rejectionValue != null && !rejectionValue.isNull() && rejectionValue.kind == JSONValueKind.STRING) {
     metadata.rejection = rejectionValue.toString();
   }


### PR DESCRIPTION
## Summary

Fixes rejection metadata not populating in subgraph queries. The frontend uploads rejection metadata as `{ "rejectionReason": "..." }` (in `TaskBoardContext.js:550`), but the IPFS handler was looking for the key `"rejection"`. Updated the handler to parse `"rejectionReason"` to match the actual frontend format.

This is a follow-up to #121 which fixed stale submission data on rejection. That fix was correct but the rejection metadata was still returning `null` because of this key mismatch.

## Test Plan

- [x] `npm run codegen` passes
- [x] `npm run build` passes
- [x] `npm run test` — all 202 tests pass
- [x] `subgraph-lint` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)