### PR TITLE
fix: add PaymasterHub ABI to PoaManager data source

### DIFF
--- a/pop-subgraph/subgraph.yaml
+++ b/pop-subgraph/subgraph.yaml
@@ -85,6 +85,8 @@ dataSources:
       abis:
         - name: PoaManager
           file: ./abis/PoaManager.json
+        - name: PaymasterHub
+          file: ./abis/PaymasterHub.json
       eventHandlers:
         - event: BeaconCreated(indexed bytes32,string,address,address)
           handler: handleBeaconCreated


### PR DESCRIPTION
## Summary

Adds the PaymasterHub ABI to the PoaManager data source's `abis` section in `subgraph.yaml`.

## Problem

The `handleInfrastructureDeployed` handler (added in #123) calls PaymasterHub contract methods (`try_getSolidarityFund`, `try_ENTRY_POINT`, `try_HATS`, `try_POA_MANAGER`) to sync initial state that was missed due to event ordering. However, the Graph node can't resolve these `eth_call`s without the PaymasterHub ABI being listed in the PoaManager data source — causing an indexing error:

```
Could not find ABI for contract "PaymasterHub", try adding it to the 'abis' section
```

## Fix

Add `PaymasterHub.json` to the PoaManager data source's abis list (2-line change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)