### PR TITLE
Update subgraph for Hoodi redeployment (block 1737268)

### DIFF
--- a/pop-subgraph/subgraph.yaml
+++ b/pop-subgraph/subgraph.yaml
@@ -4,35 +4,18 @@ indexerHints:
   prune: auto
 schema:
   file: ./schema.graphql
-# Contract Addresses - Hoodi deployment block 2341933:
-# HybridVoting: 0x9f9b7383780b48a5cff2d2426ea7fbf84669f9e6
-# DirectDemocracyVoting: 0x4e12e2b016a47e0fa834c105db01a34b52fd118f
-# Executor: 0x121bb160fb12a5489ea1c31ca897ea613ba73845
-# QuickJoin: 0x94f9594355f6164caef85368ef08434da01cce64
-# ParticipationToken: 0x5a871e3fb652beafd4383c22f4bb1888fba7cef4
-# TaskManager: 0x8c29cae36159f467df00b5e8798b25fba7fe4401
-# EducationHub: 0xa11e1ecfc3f4bf5bd87b4c8a287ad1bd46abe8a4
-# PaymentManager: 0x87cb9cef43ff0ea46cb34cf25ddc0cef632fdcce
-# UniversalAccountRegistry: 0xb159ae60b4f876c17ec00e97076d6c4ef28f16f8
-# EligibilityModule: 0x8d483a5e72eb68c7c1cf8494dbb35a2ffa6e5f8b
-# ToggleModule: 0xee900432e692ba0cb55b74858718c6ff6c9feac6
-# PasskeyAccount: 0xe74702614e7703e01dc7eef9dd2624cc4f142fc0
-# PasskeyAccountFactory: 0x7bf41cd6636c257d280092ef97a9b6c021b3fe1f
-# ImplementationRegistry: 0xdaea89717e9f0331c31811b4392894778097cf55
-# OrgRegistry: 0x0b73221009a671f91590019bdfec333e2107d82e
-# OrgDeployer: 0xadd29b387bb118118a4267ccea62e0e2344ed897
-# PoaManager: 0xbae8619670025a99a61f59cee596d34fb0d27784
-# BeaconProxy: 0x6beac5b2f6d14290f0c984170bfe3fa4641a7017
-# BeaconProxy: 0x56360d36f3c9434005247688fe310aee5f73f1f8
-# GovernanceFactory: 0x71c9201febec6f2832c0f7decb8f675200ceef2d
-# AccessFactory: 0xc924746a1d3e81ce35ca62d50d431cb60df048fa
-# ModulesFactory: 0xae9d6e064bcac315711ce19249f1794468c50ea4
-# HatsTreeSetup: 0x5a16d42d5005fb17cb9d723fff5413275b959ee0
-# PaymasterHub: 0x787175b5d8fa1acc6e16b4198fe737b85c62914e
-# BeaconProxy: 0x2cd44f3e30ff0a19acfee194e255e98f7c9a45e8
-# BeaconProxy: 0x0d513acb9360a6cc639f0d260dc94374c9efd495
-# BeaconProxy: 0xd92373f41ba6aeb7c33c535f3995f8e1a38fbe05
-# BeaconProxy: 0x5fe1eaa517bbec40a450fcb223c950a9b43ba3e8
+# Contract Addresses - Hoodi deployment block 1737268:
+# PoaManager: 0x868680dc2689fa49A8389b0313da15408C8BE340
+# GovernanceFactory: 0x2e3BCa0b6902285b7e8D747A14f118EbB8DB997D
+# OrgDeployer: 0x888daCE32d8BCdDD95BA9D490643663C25810ded
+# OrgRegistry: 0xBBf72057901d7d0F557D6f7Aa1Afc56F4F3d6072
+# PaymasterHub: 0xbe2c8713F762871b14dc2273B389a210974dB755
+# UniversalAccountRegistry: 0xDdB1DA30020861d92c27aE981ac0f4Fe8BA536F2
+# ImplementationRegistry: 0xe848C652e1Aa56BeC38f504259f5D2b98b585aed
+# HatsProtocol: 0x3bc1A0Ad72417f2d411118085256fC53CBdDd137
+# AccessFactory: 0x05Db5Cf1540683A888E7aC656d7373aa03864a8c
+# ModulesFactory: 0x0b5b1410E6e8FeE4eCd07C69CdDCf860eCc44981
+# HatsTreeSetup: 0xdc7C14AB68fcCf9bcD255f5be684EbDc892Da13a
 # NOTE: Infrastructure contracts (OrgDeployer, OrgRegistry, PaymasterHub, UniversalAccountRegistry)
 # are now dynamically discovered via InfrastructureDeployed event from PoaManager.
 # Only PoaManager and singleton factories need to be hardcoded.
@@ -61,9 +44,9 @@ dataSources:
     name: GovernanceFactory
     network: hoodi
     source:
-      address: "0x71c9201febec6f2832c0f7decb8f675200ceef2d"
+      address: "0x2e3BCa0b6902285b7e8D747A14f118EbB8DB997D"
       abi: GovernanceFactory
-      startBlock: 2341943
+      startBlock: 1737268
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9
@@ -81,9 +64,9 @@ dataSources:
     name: PoaManager
     network: hoodi
     source:
-      address: "0xbae8619670025a99a61f59cee596d34fb0d27784"
+      address: "0x868680dc2689fa49A8389b0313da15408C8BE340"
       abi: PoaManager
-      startBlock: 2341933
+      startBlock: 1737268
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9


### PR DESCRIPTION
## Summary
Updated the subgraph to index the newly redeployed infrastructure on Hoodi testnet (block 1737268). Updated hardcoded contract addresses for PoaManager and GovernanceFactory along with their start blocks.

## Changes
- **PoaManager**: `0xbae8619...` → `0x868680dc...` (block 1737268)
- **GovernanceFactory**: `0x71c92...` → `0x2e3BCa0...` (block 1737268)
- Updated infrastructure address references in subgraph comments for documentation

## Testing
All event handlers remain compatible as no event signatures changed between deployments.
- ✅ `npm run codegen` passed
- ✅ `npm run build` passed
- ✅ `npm run test` passed (202 tests)
- ✅ `subgraph-lint` passed (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)