### PR TITLE
fix: disable pruning to prevent reorg errors on Hoodi

### DIFF
--- a/pop-subgraph/subgraph.yaml
+++ b/pop-subgraph/subgraph.yaml
@@ -1,7 +1,7 @@
 # Redeploy trigger
 specVersion: 1.2.0
 indexerHints:
-  prune: auto
+  prune: never
 schema:
   file: ./schema.graphql
 # Contract Addresses - Hoodi deployment block 2353872:


### PR DESCRIPTION
## Summary
Disables block pruning on Hoodi testnet to prevent deep reorg handling failures during indexing. Hoodi testnet exhibits reorg depths that exceed the automatic pruning threshold, causing indexing to fail with "revert beyond earliest_block + reorg_threshold" errors.

## Changes
- Set `indexerHints.prune` to `never` in subgraph.yaml to retain full block history

## Test Plan
- ✅ npm run codegen - Types generated successfully
- ✅ npm run build - WebAssembly compiled successfully
- Redeployment required to index from scratch with new prune setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)