### PR TITLE
Update ABIs and subgraph for smart contract changes

### DIFF
--- a/pop-subgraph/abis/Beacon.json
+++ b/pop-subgraph/abis/Beacon.json
@@ -3,16 +3,40 @@
     "type": "constructor",
     "inputs": [
       {
-        "name": "implementation_",
+        "name": "_owner",
         "type": "address",
         "internalType": "address"
       },
       {
-        "name": "initialOwner",
+        "name": "_mirrorBeacon",
         "type": "address",
         "internalType": "address"
+      },
+      {
+        "name": "_staticImpl",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "_mode",
+        "type": "uint8",
+        "internalType": "enum SwitchableBeacon.Mode"
       }
     ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "acceptOwnership",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "cancelOwnershipTransfer",
+    "inputs": [],
+    "outputs": [],
     "stateMutability": "nonpayable"
   },
   {
@@ -24,6 +48,45 @@
         "name": "",
         "type": "address",
         "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "isMirrorMode",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "mirrorBeacon",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "mode",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint8",
+        "internalType": "enum SwitchableBeacon.Mode"
       }
     ],
     "stateMutability": "view"
@@ -43,10 +106,62 @@
   },
   {
     "type": "function",
-    "name": "renounceOwnership",
+    "name": "pendingOwner",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "pin",
+    "inputs": [
+      {
+        "name": "impl",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "pinToCurrent",
     "inputs": [],
     "outputs": [],
     "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setMirror",
+    "inputs": [
+      {
+        "name": "_mirrorBeacon",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "staticImplementation",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
     "type": "function",
@@ -63,20 +178,51 @@
   },
   {
     "type": "function",
-    "name": "upgradeTo",
-    "inputs": [
+    "name": "tryGetImplementation",
+    "inputs": [],
+    "outputs": [
       {
-        "name": "newImplementation",
+        "name": "success",
+        "type": "bool",
+        "internalType": "bool"
+      },
+      {
+        "name": "impl",
         "type": "address",
         "internalType": "address"
       }
     ],
-    "outputs": [],
-    "stateMutability": "nonpayable"
+    "stateMutability": "view"
   },
   {
     "type": "event",
-    "name": "OwnershipTransferred",
+    "name": "MirrorSet",
+    "inputs": [
+      {
+        "name": "mirrorBeacon",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ModeChanged",
+    "inputs": [
+      {
+        "name": "mode",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "enum SwitchableBeacon.Mode"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnerTransferred",
     "inputs": [
       {
         "name": "previousOwner",
@@ -95,7 +241,33 @@
   },
   {
     "type": "event",
-    "name": "Upgraded",
+    "name": "OwnershipTransferCancelled",
+    "inputs": [
+      {
+        "name": "cancelledOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OwnershipTransferStarted",
+    "inputs": [
+      {
+        "name": "pendingOwner",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Pinned",
     "inputs": [
       {
         "name": "implementation",
@@ -108,35 +280,37 @@
   },
   {
     "type": "error",
-    "name": "BeaconInvalidImplementation",
-    "inputs": [
-      {
-        "name": "implementation",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
+    "name": "ImplNotSet",
+    "inputs": []
   },
   {
     "type": "error",
-    "name": "OwnableInvalidOwner",
-    "inputs": [
-      {
-        "name": "owner",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
+    "name": "InvalidModeTransition",
+    "inputs": []
   },
   {
     "type": "error",
-    "name": "OwnableUnauthorizedAccount",
-    "inputs": [
-      {
-        "name": "account",
-        "type": "address",
-        "internalType": "address"
-      }
-    ]
+    "name": "NoPendingTransfer",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotContract",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotOwner",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotPendingOwner",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroAddress",
+    "inputs": []
   }
 ]

--- a/pop-subgraph/abis/HybridVoting.json
+++ b/pop-subgraph/abis/HybridVoting.json
@@ -716,6 +716,84 @@
   },
   {
     "type": "event",
+    "name": "ClassesReplaced",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "classesHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "classes",
+        "type": "tuple[]",
+        "indexed": false,
+        "internalType": "struct HybridVoting.ClassConfig[]",
+        "components": [
+          {
+            "name": "strategy",
+            "type": "uint8",
+            "internalType": "enum HybridVoting.ClassStrategy"
+          },
+          {
+            "name": "slicePct",
+            "type": "uint8",
+            "internalType": "uint8"
+          },
+          {
+            "name": "quadratic",
+            "type": "bool",
+            "internalType": "bool"
+          },
+          {
+            "name": "minBalance",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "asset",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "hatIds",
+            "type": "uint256[]",
+            "internalType": "uint256[]"
+          }
+        ]
+      },
+      {
+        "name": "timestamp",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "InvalidClassCount",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidSliceSum",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TooManyClasses",
+    "inputs": []
+  },
+  {
+    "type": "event",
     "name": "ProposalExecuted",
     "inputs": [
       {
@@ -820,6 +898,57 @@
     "anonymous": false
   },
   {
+    "type": "error",
+    "name": "AlreadyExecuted",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "AlreadyVoted",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "DuplicateIndex",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidIndex",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidWeight",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "LengthMismatch",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "RoleNotAllowed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "VotingExpired",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "WeightSumNot100",
+    "inputs": [
+      {
+        "name": "sum",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ]
+  },
+  {
     "type": "event",
     "name": "NewHatProposal",
     "inputs": [
@@ -912,66 +1041,33 @@
     "anonymous": false
   },
   {
-    "type": "event",
-    "name": "ClassesReplaced",
-    "inputs": [
-      {
-        "name": "version",
-        "type": "uint256",
-        "indexed": true,
-        "internalType": "uint256"
-      },
-      {
-        "name": "classesHash",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
-      },
-      {
-        "name": "classes",
-        "type": "tuple[]",
-        "indexed": false,
-        "internalType": "struct HybridVoting.ClassConfig[]",
-        "components": [
-          {
-            "name": "strategy",
-            "type": "uint8",
-            "internalType": "enum HybridVoting.ClassStrategy"
-          },
-          {
-            "name": "slicePct",
-            "type": "uint8",
-            "internalType": "uint8"
-          },
-          {
-            "name": "quadratic",
-            "type": "bool",
-            "internalType": "bool"
-          },
-          {
-            "name": "minBalance",
-            "type": "uint256",
-            "internalType": "uint256"
-          },
-          {
-            "name": "asset",
-            "type": "address",
-            "internalType": "address"
-          },
-          {
-            "name": "hatIds",
-            "type": "uint256[]",
-            "internalType": "uint256[]"
-          }
-        ]
-      },
-      {
-        "name": "timestamp",
-        "type": "uint64",
-        "indexed": false,
-        "internalType": "uint64"
-      }
-    ],
-    "anonymous": false
+    "type": "error",
+    "name": "DurationOutOfRange",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyTitle",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TargetSelf",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TitleTooLong",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TooManyCalls",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "TooManyOptions",
+    "inputs": []
   }
 ]

--- a/pop-subgraph/abis/OrgDeployer.json
+++ b/pop-subgraph/abis/OrgDeployer.json
@@ -464,6 +464,58 @@
                 ]
               }
             ]
+          },
+          {
+            "name": "paymasterConfig",
+            "type": "tuple",
+            "internalType": "struct OrgDeployer.PaymasterConfig",
+            "components": [
+              {
+                "name": "operatorRoleIndex",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "autoWhitelistContracts",
+                "type": "bool",
+                "internalType": "bool"
+              },
+              {
+                "name": "maxFeePerGas",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "maxPriorityFeePerGas",
+                "type": "uint256",
+                "internalType": "uint256"
+              },
+              {
+                "name": "maxCallGas",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "maxVerificationGas",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "maxPreVerificationGas",
+                "type": "uint32",
+                "internalType": "uint32"
+              },
+              {
+                "name": "defaultBudgetCapPerEpoch",
+                "type": "uint128",
+                "internalType": "uint128"
+              },
+              {
+                "name": "defaultBudgetEpochLen",
+                "type": "uint32",
+                "internalType": "uint32"
+              }
+            ]
           }
         ]
       }
@@ -513,11 +565,16 @@
             "name": "paymentManager",
             "type": "address",
             "internalType": "address"
+          },
+          {
+            "name": "eligibilityModule",
+            "type": "address",
+            "internalType": "address"
           }
         ]
       }
     ],
-    "stateMutability": "nonpayable"
+    "stateMutability": "payable"
   },
   {
     "type": "function",

--- a/pop-subgraph/abis/PaymasterHub.json
+++ b/pop-subgraph/abis/PaymasterHub.json
@@ -653,6 +653,96 @@
   },
   {
     "type": "function",
+    "name": "registerAndConfigureOrg",
+    "inputs": [
+      {
+        "name": "orgId",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "adminHatId",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "config",
+        "type": "tuple",
+        "internalType": "struct PaymasterHub.DeployConfig",
+        "components": [
+          {
+            "name": "operatorHatId",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "maxFeePerGas",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "maxPriorityFeePerGas",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "maxCallGas",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "maxVerificationGas",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "maxPreVerificationGas",
+            "type": "uint32",
+            "internalType": "uint32"
+          },
+          {
+            "name": "ruleTargets",
+            "type": "address[]",
+            "internalType": "address[]"
+          },
+          {
+            "name": "ruleSelectors",
+            "type": "bytes4[]",
+            "internalType": "bytes4[]"
+          },
+          {
+            "name": "ruleAllowed",
+            "type": "bool[]",
+            "internalType": "bool[]"
+          },
+          {
+            "name": "ruleMaxCallGasHints",
+            "type": "uint32[]",
+            "internalType": "uint32[]"
+          },
+          {
+            "name": "budgetSubjectKeys",
+            "type": "bytes32[]",
+            "internalType": "bytes32[]"
+          },
+          {
+            "name": "budgetCapsPerEpoch",
+            "type": "uint128[]",
+            "internalType": "uint128[]"
+          },
+          {
+            "name": "budgetEpochLens",
+            "type": "uint32[]",
+            "internalType": "uint32[]"
+          }
+        ]
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
     "name": "registerOrg",
     "inputs": [
       {

--- a/pop-subgraph/abis/QuickJoin.json
+++ b/pop-subgraph/abis/QuickJoin.json
@@ -149,13 +149,6 @@
   },
   {
     "type": "function",
-    "name": "quickJoinNoUser",
-    "inputs": [],
-    "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
     "name": "quickJoinNoUserMasterDeploy",
     "inputs": [
       {
@@ -165,47 +158,6 @@
       }
     ],
     "outputs": [],
-    "stateMutability": "nonpayable"
-  },
-  {
-    "type": "function",
-    "name": "quickJoinWithPasskey",
-    "inputs": [
-      {
-        "name": "passkey",
-        "type": "tuple",
-        "internalType": "struct QuickJoin.PasskeyEnrollment",
-        "components": [
-          {
-            "name": "credentialId",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "publicKeyX",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "publicKeyY",
-            "type": "bytes32",
-            "internalType": "bytes32"
-          },
-          {
-            "name": "salt",
-            "type": "uint256",
-            "internalType": "uint256"
-          }
-        ]
-      }
-    ],
-    "outputs": [
-      {
-        "name": "account",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
     "stateMutability": "nonpayable"
   },
   {
@@ -680,31 +632,6 @@
         "type": "address",
         "indexed": true,
         "internalType": "address"
-      },
-      {
-        "name": "hatIds",
-        "type": "uint256[]",
-        "indexed": false,
-        "internalType": "uint256[]"
-      }
-    ],
-    "anonymous": false
-  },
-  {
-    "type": "event",
-    "name": "QuickJoinedWithPasskey",
-    "inputs": [
-      {
-        "name": "account",
-        "type": "address",
-        "indexed": true,
-        "internalType": "address"
-      },
-      {
-        "name": "credentialId",
-        "type": "bytes32",
-        "indexed": true,
-        "internalType": "bytes32"
       },
       {
         "name": "hatIds",

--- a/pop-subgraph/src/quick-join.ts
+++ b/pop-subgraph/src/quick-join.ts
@@ -8,7 +8,6 @@ import {
   MemberHatIdsUpdated as MemberHatIdsUpdatedEvent,
   AddressesUpdated as AddressesUpdatedEvent,
   UniversalFactoryUpdated as UniversalFactoryUpdatedEvent,
-  QuickJoinedWithPasskey as QuickJoinedWithPasskeyEvent,
   QuickJoinedWithPasskeyByMaster as QuickJoinedWithPasskeyByMasterEvent,
   RegisterAndQuickJoined as RegisterAndQuickJoinedEvent,
   RegisterAndQuickJoinedWithPasskey as RegisterAndQuickJoinedWithPasskeyEvent,
@@ -255,50 +254,6 @@ export function handleUniversalFactoryUpdated(event: UniversalFactoryUpdatedEven
 
   contract.universalFactory = event.params.universalFactory;
   contract.save();
-}
-
-export function handleQuickJoinedWithPasskey(event: QuickJoinedWithPasskeyEvent): void {
-  let contractAddress = event.address;
-  let contract = QuickJoinContract.load(contractAddress);
-  if (!contract) {
-    log.warning("QuickJoinContract not found at address {}", [
-      contractAddress.toHexString()
-    ]);
-    return;
-  }
-
-  // Create PasskeyQuickJoin event record
-  let eventId = event.transaction.hash.concatI32(event.logIndex.toI32());
-  let passkeyJoin = new PasskeyQuickJoin(eventId);
-  passkeyJoin.quickJoinContract = contractAddress;
-  passkeyJoin.credentialId = event.params.credentialId;
-  passkeyJoin.hatIds = event.params.hatIds;
-  passkeyJoin.timestamp = event.block.timestamp;
-  passkeyJoin.blockNumber = event.block.number;
-  passkeyJoin.transactionHash = event.transaction.hash;
-
-  // Link to PasskeyAccount - account should be created by PasskeyAccountFactory in the same transaction
-  passkeyJoin.account = event.params.account;
-  passkeyJoin.save();
-
-  // Create User and RoleWearer entities for the passkey account
-  let user = createUserOnJoin(
-    contract.organization,
-    event.params.account,
-    "QuickJoinWithPasskey",
-    event.block.timestamp,
-    event.block.number
-  );
-
-  if (user) {
-    let hatIds = event.params.hatIds;
-    for (let i = 0; i < hatIds.length; i++) {
-      if (shouldCreateRoleWearer(contract.organization, hatIds[i], event.params.account)) {
-        getOrCreateRoleWearer(contract.organization, hatIds[i], event.params.account, event);
-        recordUserHatChange(user, hatIds[i], true, event);
-      }
-    }
-  }
 }
 
 export function handleQuickJoinedWithPasskeyByMaster(event: QuickJoinedWithPasskeyByMasterEvent): void {

--- a/pop-subgraph/subgraph.yaml
+++ b/pop-subgraph/subgraph.yaml
@@ -4,35 +4,35 @@ indexerHints:
   prune: never
 schema:
   file: ./schema.graphql
-# Contract Addresses - Hoodi deployment block 2353872:
-# HybridVoting: 0x3907c37fb778c6b6ad7b25c154323089ddbedaf7
-# DirectDemocracyVoting: 0x31d5907353f12913a2b1d45f07361190073535a1
-# Executor: 0x78cbd28f830b77a74a2544dcfed0cbaa7e635bea
-# QuickJoin: 0x79e50dcd342e3636c7761123592f750b3bcde892
-# ParticipationToken: 0xc354c61827c2329772bca25972341c80699bae37
-# TaskManager: 0xc2140bdf4c5df5528a4571edc51656255416390b
-# EducationHub: 0xcbd939d76ba428f59fc60e570e4f79fb59236225
-# PaymentManager: 0xa81bb975c5881801faeabcf20431c1a3509422df
-# UniversalAccountRegistry: 0x176ea172fc9956f10c71b51a6db22c674b82513d
-# EligibilityModule: 0x52a9d58c740d58a72a00042b3b2101e34730ba85
-# ToggleModule: 0xa85351e1f4afda94871214049345533572f1b118
-# PasskeyAccount: 0xff1299d4454a2de175ac31a593f29d530dadadf2
-# PasskeyAccountFactory: 0xf89d926ea9a55bbc394061dda70f78a91ef0bdb6
-# ImplementationRegistry: 0x5438c398e84ea6b5ea8bf9e3e40e5402897b900e
-# OrgRegistry: 0x1e9239492b782ed31a9e9367f6cd8915f12669ce
-# OrgDeployer: 0xe8bc217339f343a172338b123ffb238917f314a0
-# PoaManager: 0x5be780aa62a1b15fa794668ff0298dd5528a6b03
-# BeaconProxy: 0x19f5209788dde3b7b13380418572a3778ebfe602
-# BeaconProxy: 0xa2ee153f2ff448b9f5d4ee9ec0743f140ac58535
-# GovernanceFactory: 0x45f015d0032109961980d9231ff878128a82ce30
-# AccessFactory: 0x92102f550236612ecb3534dbd57cc617274d9a27
-# ModulesFactory: 0xb6dccf8b3d74e3afaf63e001b7aa476c85447dae
-# HatsTreeSetup: 0xdfdabb6eda8ee4e00d36fc2a15e44e521497e7cc
-# PaymasterHub: 0xc319eb7e55825a63d9dbc5856dbcb0c34b304f07
-# BeaconProxy: 0xf429af29ce4943c6b327945bb01c6a5c6608491b
-# BeaconProxy: 0xe2a53401b48c6e60a2372dc03d0d4c56d7a11f08
-# BeaconProxy: 0xb248f46a7ca20c78a2189af2df4e882c3f8099f8
-# BeaconProxy: 0xb8c88367904c09bb62c4ddf37e892d439c80e5eb
+# Contract Addresses - Hoodi deployment block 2354418:
+# HybridVoting: 0xd5b1376135ad2bda96413d421a89dc1989208ed6
+# DirectDemocracyVoting: 0x9cd3dcadd8a44570314a1925a89b21bf5b9e9d32
+# Executor: 0xaf0cf88369c13763532087fad0bf7452678f5ce5
+# QuickJoin: 0xd03ba38f0e08850d72c132ccc3d1b02c24e6371c
+# ParticipationToken: 0xc224098ab27792a1bc9ef715f7ccd97c23148822
+# TaskManager: 0xd1899bf7b224c52997447ce831ffe5a23c02ec8b
+# EducationHub: 0x24f031ec57b78cb7b798199452276c9c1a7db4ec
+# PaymentManager: 0x05f6beaf458f6317874ef1cd50545617dd063382
+# UniversalAccountRegistry: 0xd5532331f3f4bf8c20708879af7bd9f60b1e3c7d
+# EligibilityModule: 0x72f04e60dccd4e36495b883b6a4b4fbd6fede4b7
+# ToggleModule: 0x55c25b84cfff340196e15c2a032ed6d882ca58f0
+# PasskeyAccount: 0x78e072aa79c06a4045ace9d12d2db79994cce336
+# PasskeyAccountFactory: 0x6151a7d29d196aee4e11ea174e4ed1e39bd50b45
+# ImplementationRegistry: 0xeb2f969c89a67272e74b72dc772aa53ba154ffcc
+# OrgRegistry: 0x3d10830aa4ffccd9ad69c21885b3d5e5314faa9c
+# OrgDeployer: 0xbdbd25fa54e8cee692898c8ec90d447ce4427d17
+# PoaManager: 0x8accd6d2328f024cb37527c636c3823b06222d33
+# BeaconProxy: 0x4e0c568ae4a23ec0a931ba25660693b728540da1
+# BeaconProxy: 0xb2d76c93db4377bf78aec69138850f325ae963d4
+# GovernanceFactory: 0x1f97ccb5e31109311589bf6d3494afb38a054395
+# AccessFactory: 0xfdcacc317b056fa3b23b980bbd28b8445847866b
+# ModulesFactory: 0xc6b7ce34cdb773267ca1460de6752e7066508d84
+# HatsTreeSetup: 0x574576d68b9c6f159831493314f2030acfe436ca
+# PaymasterHub: 0x4209072baa4a4065e0d7067b9b294d68eb7da87a
+# BeaconProxy: 0x271440a94b95367538721c1507c152e546aeb05a
+# BeaconProxy: 0x595ce07f89b27d77b9b882ee105c0d11ce8a8af2
+# BeaconProxy: 0x0a36408c0b8237044884884fc04ba667d92bcab6
+# BeaconProxy: 0x7ea866284eb5446be3f228eadd0d2608e62b75cb
 # NOTE: Infrastructure contracts (OrgDeployer, OrgRegistry, PaymasterHub, UniversalAccountRegistry)
 # are now dynamically discovered via InfrastructureDeployed event from PoaManager.
 # Only PoaManager and singleton factories need to be hardcoded.
@@ -61,9 +61,9 @@ dataSources:
     name: GovernanceFactory
     network: hoodi
     source:
-      address: "0x45f015d0032109961980d9231ff878128a82ce30"
+      address: "0x1f97ccb5e31109311589bf6d3494afb38a054395"
       abi: GovernanceFactory
-      startBlock: 2353881
+      startBlock: 2354429
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9
@@ -81,9 +81,9 @@ dataSources:
     name: PoaManager
     network: hoodi
     source:
-      address: "0x5be780aa62a1b15fa794668ff0298dd5528a6b03"
+      address: "0x8accd6d2328f024cb37527c636c3823b06222d33"
       abi: PoaManager
-      startBlock: 2353872
+      startBlock: 2354418
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9
@@ -572,8 +572,6 @@ templates:
           handler: handleAddressesUpdated
         - event: UniversalFactoryUpdated(indexed address)
           handler: handleUniversalFactoryUpdated
-        - event: QuickJoinedWithPasskey(indexed address,indexed bytes32,uint256[])
-          handler: handleQuickJoinedWithPasskey
         - event: QuickJoinedWithPasskeyByMaster(indexed address,indexed address,indexed bytes32,uint256[])
           handler: handleQuickJoinedWithPasskeyByMaster
         - event: RegisterAndQuickJoined(indexed address,string,uint256[])


### PR DESCRIPTION
## Summary

Updated the subgraph to reflect smart contract refactoring, including event/function removals and ABI consolidation:

- **QuickJoin**: Removed `QuickJoinedWithPasskey` event (corresponding function was removed from contract)
- **HybridVoting**: Merged ABI from sub-contracts (HybridVotingCore, HybridVotingProposals, HybridVotingConfig) to preserve all 12 emitted events despite code refactoring
- **Contract Addresses**: Updated PoaManager, GovernanceFactory, and all 27 contract addresses for the latest Hoodi deployment (starting block 2354418)
- **Other ABIs**: Updated OrgDeployer (deployFullOrg signature changed), PaymasterHub (new function), and Beacon (updated from SwitchableBeacon)

## Test plan

✅ `npm run codegen` — types generated successfully
✅ `npm run build` — all templates compiled without errors
✅ `npm run test` — all 202 tests passed

🔗 Generated with [Claude Code](https://claude.com/claude-code)