### PR TITLE
Update contract addresses for Hoodi deployment (block 2358852)

### DIFF
--- a/pop-subgraph/networks.json
+++ b/pop-subgraph/networks.json
@@ -1,8 +1,8 @@
 {
   "hoodi": {
     "OrgDeployer": {
-      "address": "0xaf2a9c3907e098fe831c5e0f859f18e8b7eb7f89",
-      "startBlock": 2358347
+      "address": "0xfB57C2053ca9DDBD5b4fd3cf8378faDD63e40DbC",
+      "startBlock": 2358852
     }
   }
 }

--- a/pop-subgraph/subgraph.yaml
+++ b/pop-subgraph/subgraph.yaml
@@ -4,35 +4,21 @@ indexerHints:
   prune: never
 schema:
   file: ./schema.graphql
-# Contract Addresses - Hoodi deployment block 2358347:
-# HybridVoting: 0x233ec0b86854cdab0fc66b2c1c56fab4787b1a89
-# DirectDemocracyVoting: 0x4ef65803dd414dc35d7ab6e334d187cb71d4fd71
-# Executor: 0x72e80b31bab71e3f0aba6356a07f4448e5fcc787
-# QuickJoin: 0xb705cdaf47cb3cdf10a52527063da07382a1db74
-# ParticipationToken: 0x2346a053477576007139a716d30a4a8f94951da7
-# TaskManager: 0x92d1a8b0504dddbf21c840becdacdca905ad37bf
-# EducationHub: 0x249925dd71d50349b2d93282c5f115497af32761
-# PaymentManager: 0x89f71d294144a8970e1b6fbcc22c24aadbfc941b
-# UniversalAccountRegistry: 0xa6f3b73f04909bce39123e219c3a2d863803667c
-# EligibilityModule: 0x0eccb5c70e5b9dc75923535203bad1d41bde3abf
-# ToggleModule: 0x59358fff81d6646c5e0985415ffd3d1687f25db6
-# PasskeyAccount: 0xb700e2ce6c4892c079a1e21d85e2208117ef4ffe
-# PasskeyAccountFactory: 0x686dd48a686d67e3875605c5ea99cc9f6eb91fa4
-# ImplementationRegistry: 0xb6827962e6ae3beae9788fed9b557b811af31644
-# OrgRegistry: 0x5c51131104a0ded685cf83261b05b416ba342e7e
-# OrgDeployer: 0xaf2a9c3907e098fe831c5e0f859f18e8b7eb7f89
-# PoaManager: 0x3780ee4b767499a056c739a90d3620b4ed8d4b8b
-# BeaconProxy: 0x2874d3a8f93c21357e19fbe014696fb06711d7e1
-# BeaconProxy: 0xd1c52e2ff9ef8b9a573811b1e623a63141c3c63a
-# GovernanceFactory: 0x1df5081b11b1c3e2a13820cd3d5505fc6902fd89
-# AccessFactory: 0x653ecb78c14408e267809336598da2d9fc74ad15
-# ModulesFactory: 0x7cda2e387592882ef0dfbebb0a2a428823531b5b
-# HatsTreeSetup: 0xe2c14ea9457b828008fa80f9e38685bb650924f3
-# PaymasterHub: 0xde9c4f6991543ecca80d9c039a5837c9cb631715
-# BeaconProxy: 0x9ac8a95fca997df5a556dc1b920a2881a4155b01
-# BeaconProxy: 0xfd4b52d752cbd855502f2b8127e8424e521ad3f4
-# BeaconProxy: 0xb695a6e2be6c8ecc292848af72abc66c09cbd748
-# BeaconProxy: 0x4d81d82a1a5061fbd00d3d7bfbcc9c7ea9e2f474
+# Contract Addresses - Hoodi deployment block 2358852:
+# OrgDeployer: 0xfB57C2053ca9DDBD5b4fd3cf8378faDD63e40DbC
+# UniversalAccountRegistry: 0x4820Aa2019EC06729fF1A101369608D64067847a
+# PaymasterHub: 0x036430226c5Df5Fe2b7A128f3Eb999a2C6B1B6d5
+# PoaManager: 0xcFB538f47603dcea81f040cb4Bd05899FB6F9804
+# OrgRegistry: 0x8ea03293982F99a6817FB261c7e64d6F72559A6B
+# ImplementationRegistry: 0x10c6Eee29e0D8D56Cf7e7db86899f6E0Fc46CA4f
+# HatsProtocol: 0x3bc1A0Ad72417f2d411118085256fC53CBdDd137
+# GovernanceFactory: 0x23dA8aE6bc6F39d99Df2FA0764428b5Ce853092C
+# AccessFactory: 0xE6786bFe5beA46E4342dD9742294e8e68d6d335e
+# ModulesFactory: 0xC4672E30861C92C7beaff91ef62Af6241B572556
+# HatsTreeSetup: 0x6EeE457293eBF1EAa09E89Cb5f912FcE9D7515Ed
+# UniversalPasskeyFactory: 0xEB94E85C75acD83d6CBC4784Fb79Ef8e47E00f66
+# PasskeyAccountBeacon: 0x16caBCEDe5d6A1e9D8eC2E80950F47C459696f46
+# PasskeyAccountFactoryBeacon: 0xced1e0dD171baBDd5e3927e7227dD34fd86d5AfC
 # NOTE: Infrastructure contracts (OrgDeployer, OrgRegistry, PaymasterHub, UniversalAccountRegistry)
 # are now dynamically discovered via InfrastructureDeployed event from PoaManager.
 # Only PoaManager and singleton factories need to be hardcoded.
@@ -61,9 +47,9 @@ dataSources:
     name: GovernanceFactory
     network: hoodi
     source:
-      address: "0x1df5081b11b1c3e2a13820cd3d5505fc6902fd89"
+      address: "0x23dA8aE6bc6F39d99Df2FA0764428b5Ce853092C"
       abi: GovernanceFactory
-      startBlock: 2358359
+      startBlock: 2358853
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9
@@ -81,9 +67,9 @@ dataSources:
     name: PoaManager
     network: hoodi
     source:
-      address: "0x3780ee4b767499a056c739a90d3620b4ed8d4b8b"
+      address: "0xcFB538f47603dcea81f040cb4Bd05899FB6F9804"
       abi: PoaManager
-      startBlock: 2358347
+      startBlock: 2358852
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9


### PR DESCRIPTION
## Summary
Updates PoaManager and GovernanceFactory contract addresses and startBlocks discovered via binary search. Updates OrgDeployer address in networks.json. All contract addresses and deployment metadata have been updated to reflect the new Hoodi redeployment.

## Testing
- npm run codegen ✓
- npm run build ✓
- npm run test (202 tests) ✓
- subgraph-lint ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)