### PR TITLE
feat: profile metadata indexing

### DIFF
--- a/pop-subgraph/abis/UniversalAccountRegistry.json
+++ b/pop-subgraph/abis/UniversalAccountRegistry.json
@@ -395,6 +395,25 @@
   },
   {
     "type": "event",
+    "name": "ProfileMetadataUpdated",
+    "inputs": [
+      {
+        "name": "user",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "metadataHash",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "PasskeyFactoryUpdated",
     "inputs": [
       {

--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -1142,8 +1142,21 @@ type Account @entity(immutable: false) {
   lastUpdatedAt: BigInt!
   deletedAt: BigInt
   deletedAtBlock: BigInt
+  profileMetadataHash: Bytes
+  metadata: AccountMetadata
   users: [User!]! @derivedFrom(field: "account")
   usernameChanges: [UsernameChange!]! @derivedFrom(field: "account")
+}
+
+type AccountMetadata @entity(immutable: false) {
+  id: String! # IPFS CID
+  account: Account
+  bio: String
+  avatar: String # IPFS CID for avatar image
+  github: String
+  twitter: String
+  website: String
+  indexedAt: BigInt
 }
 
 type UsernameChange @entity(immutable: true) {

--- a/pop-subgraph/src/account-metadata.ts
+++ b/pop-subgraph/src/account-metadata.ts
@@ -1,0 +1,80 @@
+import { Bytes, dataSource, json, BigInt, JSONValueKind } from "@graphprotocol/graph-ts";
+import { AccountMetadata } from "../generated/schema";
+
+/**
+ * Handler for IPFS file data source that parses account profile metadata JSON.
+ *
+ * Expected JSON structure:
+ * {
+ *   bio: "Building decentralized organizations",
+ *   avatar: "QmXxx...",      // IPFS CID for avatar image
+ *   github: "hudsonhrh",
+ *   twitter: "@hudsonhrh",
+ *   website: "https://poa.earth"
+ * }
+ */
+export function handleAccountMetadata(content: Bytes): void {
+  let ipfsHash = dataSource.stringParam();
+
+  let context = dataSource.context();
+  let userAddress = context.getBytes("userAddress");
+
+  let jsonResult = json.try_fromBytes(content);
+  if (jsonResult.isError) {
+    let metadata = AccountMetadata.load(ipfsHash);
+    if (metadata == null) {
+      metadata = new AccountMetadata(ipfsHash);
+      metadata.account = userAddress;
+      metadata.save();
+    }
+    return;
+  }
+
+  let jsonValue = jsonResult.value;
+  if (!jsonValue.isNull() && jsonValue.kind == JSONValueKind.OBJECT) {
+    let jsonObject = jsonValue.toObject();
+
+    // Load or create — profile metadata is mutable (user can update)
+    let metadata = AccountMetadata.load(ipfsHash);
+    if (metadata == null) {
+      metadata = new AccountMetadata(ipfsHash);
+    }
+
+    metadata.account = userAddress;
+
+    let bioValue = jsonObject.get("bio");
+    if (bioValue != null && !bioValue.isNull() && bioValue.kind == JSONValueKind.STRING) {
+      metadata.bio = bioValue.toString();
+    }
+
+    let avatarValue = jsonObject.get("avatar");
+    if (avatarValue != null && !avatarValue.isNull() && avatarValue.kind == JSONValueKind.STRING) {
+      metadata.avatar = avatarValue.toString();
+    }
+
+    let githubValue = jsonObject.get("github");
+    if (githubValue != null && !githubValue.isNull() && githubValue.kind == JSONValueKind.STRING) {
+      metadata.github = githubValue.toString();
+    }
+
+    let twitterValue = jsonObject.get("twitter");
+    if (twitterValue != null && !twitterValue.isNull() && twitterValue.kind == JSONValueKind.STRING) {
+      metadata.twitter = twitterValue.toString();
+    }
+
+    let websiteValue = jsonObject.get("website");
+    if (websiteValue != null && !websiteValue.isNull() && websiteValue.kind == JSONValueKind.STRING) {
+      metadata.website = websiteValue.toString();
+    }
+
+    metadata.indexedAt = BigInt.fromI32(0);
+    metadata.save();
+  } else {
+    let metadata = AccountMetadata.load(ipfsHash);
+    if (metadata == null) {
+      metadata = new AccountMetadata(ipfsHash);
+      metadata.account = userAddress;
+      metadata.save();
+    }
+  }
+}

--- a/pop-subgraph/src/universal-account-registry.ts
+++ b/pop-subgraph/src/universal-account-registry.ts
@@ -1,4 +1,4 @@
-import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts";
+import { Address, BigInt, Bytes, DataSourceContext } from "@graphprotocol/graph-ts";
 import {
   Initialized as InitializedEvent,
   UserRegistered as UserRegisteredEvent,
@@ -6,7 +6,8 @@ import {
   UserDeleted as UserDeletedEvent,
   BatchRegistered as BatchRegisteredEvent,
   OwnershipTransferred as OwnershipTransferredEvent,
-  PasskeyFactoryUpdated as PasskeyFactoryUpdatedEvent
+  PasskeyFactoryUpdated as PasskeyFactoryUpdatedEvent,
+  ProfileMetadataUpdated as ProfileMetadataUpdatedEvent
 } from "../generated/templates/UniversalAccountRegistry/UniversalAccountRegistry";
 import {
   UniversalAccountRegistry,
@@ -16,6 +17,19 @@ import {
   BatchRegistration,
   RegistryOwnershipTransfer
 } from "../generated/schema";
+import { AccountMetadata as AccountMetadataTemplate } from "../generated/templates";
+
+function bytes32ToCid(hash: Bytes): string {
+  let prefix = Bytes.fromHexString("0x1220");
+  let multihash = new Bytes(34);
+  for (let i = 0; i < 2; i++) {
+    multihash[i] = prefix[i];
+  }
+  for (let i = 0; i < 32; i++) {
+    multihash[i + 2] = hash[i];
+  }
+  return multihash.toBase58();
+}
 
 export function handleInitialized(event: InitializedEvent): void {
   let contractAddress = event.address;
@@ -227,4 +241,39 @@ export function handlePasskeyFactoryUpdated(event: PasskeyFactoryUpdatedEvent): 
     registry.passkeyFactory = event.params.factory;
     registry.save();
   }
+}
+
+export function handleProfileMetadataUpdated(event: ProfileMetadataUpdatedEvent): void {
+  let userAddress = event.params.user;
+  let metadataHash = event.params.metadataHash;
+
+  let account = Account.load(userAddress);
+  if (!account) {
+    return;
+  }
+
+  // Store raw hash on Account
+  account.profileMetadataHash = metadataHash;
+  account.lastUpdatedAt = event.block.timestamp;
+
+  // Skip IPFS fetch for zero hash (clear profile)
+  let zeroHash = Bytes.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000000");
+  if (metadataHash.equals(zeroHash)) {
+    account.profileMetadataHash = null;
+    account.metadata = null;
+    account.save();
+    return;
+  }
+
+  // Convert bytes32 sha256 digest to IPFS CIDv0
+  let ipfsCid = bytes32ToCid(metadataHash);
+
+  // Link Account to AccountMetadata
+  account.metadata = ipfsCid;
+  account.save();
+
+  // Create IPFS file data source to fetch and parse the metadata
+  let context = new DataSourceContext();
+  context.setBytes("userAddress", userAddress);
+  AccountMetadataTemplate.createWithContext(ipfsCid, context);
 }

--- a/pop-subgraph/subgraph.yaml
+++ b/pop-subgraph/subgraph.yaml
@@ -262,6 +262,7 @@ templates:
       entities:
         - UniversalAccountRegistry
         - Account
+        - AccountMetadata
         - UsernameChange
         - AccountDeletion
         - BatchRegistration
@@ -284,6 +285,8 @@ templates:
           handler: handleOwnershipTransferred
         - event: PasskeyFactoryUpdated(indexed address)
           handler: handlePasskeyFactoryUpdated
+        - event: ProfileMetadataUpdated(indexed address,bytes32)
+          handler: handleProfileMetadataUpdated
       file: ./src/universal-account-registry.ts
   - kind: ethereum
     name: TaskManager
@@ -967,3 +970,16 @@ templates:
       abis:
         - name: TaskManager
           file: ./abis/TaskManager.json
+  - kind: file/ipfs
+    name: AccountMetadata
+    network: arbitrum-one
+    mapping:
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      file: ./src/account-metadata.ts
+      handler: handleAccountMetadata
+      entities:
+        - AccountMetadata
+      abis:
+        - name: UniversalAccountRegistry
+          file: ./abis/UniversalAccountRegistry.json


### PR DESCRIPTION
## Summary

- Add `AccountMetadata` entity to schema (bio, avatar, github, twitter, website)
- Add `profileMetadataHash` and `metadata` fields to `Account` entity
- Index `ProfileMetadataUpdated(indexed address, bytes32)` event on UniversalAccountRegistry
- Add `account-metadata.ts` IPFS file data source handler to parse profile JSON
- Add `ProfileMetadataUpdated` event to UAR ABI
- Zero-hash clears both `profileMetadataHash` and `metadata` fields

Depends on smart contract upgrade: `UniversalAccountRegistry v4` (adds `setProfileMetadata` + `ProfileMetadataUpdated` event).

## Test plan

- [ ] `npm run codegen && npm run build` passes
- [ ] Deploy to staging subgraph and verify `ProfileMetadataUpdated` events are indexed
- [ ] Query `account { metadata { bio github twitter website } }` returns parsed IPFS data
- [ ] Verify zero-hash update clears metadata fields
- [ ] Verify orphaned AccountMetadata entities from previous profile versions don't cause issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)