### PR TITLE
fix: resolve causality region conflict crashing indexer

### DIFF
--- a/pop-subgraph/src/eligibility-module.ts
+++ b/pop-subgraph/src/eligibility-module.ts
@@ -25,6 +25,7 @@ import {
 import {
   EligibilityModuleContract,
   Hat,
+  HatMetadata,
   WearerEligibility,
   VouchConfig,
   Vouch,
@@ -89,13 +90,16 @@ function createHatIpfsDataSource(metadataCID: Bytes, hatEntityId: string): void 
   // Convert bytes32 sha256 digest to IPFS CIDv0 string
   let ipfsCid = bytes32ToCid(metadataCID);
 
+  // Skip if HatMetadata already exists - prevents duplicate file data sources
+  let existing = HatMetadata.load(ipfsCid);
+  if (existing != null) {
+    return;
+  }
+
   // Create context to pass hatEntityId to the IPFS handler
   let context = new DataSourceContext();
   context.setString("hatEntityId", hatEntityId);
 
-  // Create the file data source with context
-  // If IPFS is unavailable or slow, this will be retried automatically
-  // and won't block the main chain indexing
   HatMetadataTemplate.createWithContext(ipfsCid, context);
 }
 

--- a/pop-subgraph/src/hat-metadata.ts
+++ b/pop-subgraph/src/hat-metadata.ts
@@ -1,5 +1,5 @@
-import { Bytes, dataSource, json, BigInt, JSONValueKind, log } from "@graphprotocol/graph-ts";
-import { HatMetadata, Hat } from "../generated/schema";
+import { Bytes, dataSource, json, BigInt, JSONValueKind } from "@graphprotocol/graph-ts";
+import { HatMetadata } from "../generated/schema";
 
 /**
  * Handler for IPFS file data source that parses hat metadata JSON.
@@ -11,8 +11,6 @@ import { HatMetadata, Hat } from "../generated/schema";
  * }
  *
  * This handler extracts both 'name' and 'description' from the IPFS JSON.
- * If 'name' is found and the Hat entity doesn't already have a name set
- * (from HatMetadataUpdated event), it will update the Hat.name field.
  *
  * This handler is resilient to malformed data - if parsing fails or fields
  * are missing, the entity will be created with whatever data is available.
@@ -52,12 +50,10 @@ export function handleHatMetadata(content: Bytes): void {
 
     // Parse name
     let nameValue = jsonObject.get("name");
-    let parsedName: string | null = null;
     if (nameValue != null && !nameValue.isNull() && nameValue.kind == JSONValueKind.STRING) {
       let nameStr = nameValue.toString();
       if (nameStr.length > 0) {
         metadata.name = nameStr;
-        parsedName = nameStr;
       }
     }
 
@@ -75,16 +71,6 @@ export function handleHatMetadata(content: Bytes): void {
     metadata.indexedAt = BigInt.fromI32(0);
 
     metadata.save();
-
-    // If we parsed a name, also update the Hat entity if it doesn't have a name yet
-    if (parsedName != null) {
-      let hat = Hat.load(hatEntityId);
-      if (hat != null && hat.name == null) {
-        hat.name = parsedName;
-        hat.save();
-        log.info("Updated Hat.name from IPFS metadata for hat {}: {}", [hatEntityId, parsedName!]);
-      }
-    }
   } else {
     // Not a JSON object - create entity with just the ID and hat link
     let metadata = new HatMetadata(ipfsHash);

--- a/pop-subgraph/src/proposal-metadata.ts
+++ b/pop-subgraph/src/proposal-metadata.ts
@@ -95,8 +95,13 @@ export function handleProposalMetadata(content: Bytes): void {
     // Parse createdAt timestamp
     let createdAtValue = jsonObject.get("createdAt");
     if (createdAtValue != null && !createdAtValue.isNull() && createdAtValue.kind == JSONValueKind.NUMBER) {
-      // createdAt is in milliseconds, convert to BigInt
-      metadata.createdAt = BigInt.fromString(createdAtValue.toBigInt().toString());
+      // createdAt is in milliseconds — strip any decimal to safely convert to BigInt
+      let raw = createdAtValue.toF64().toString();
+      let dotIndex = raw.indexOf(".");
+      if (dotIndex >= 0) {
+        raw = raw.substring(0, dotIndex);
+      }
+      metadata.createdAt = BigInt.fromString(raw);
     }
 
     metadata.save();

--- a/pop-subgraph/src/token-request-metadata.ts
+++ b/pop-subgraph/src/token-request-metadata.ts
@@ -49,7 +49,12 @@ export function handleTokenRequestMetadata(content: Bytes): void {
   // Parse submittedAt
   let submittedAtValue = jsonObject.get("submittedAt");
   if (submittedAtValue != null && !submittedAtValue.isNull() && submittedAtValue.kind == JSONValueKind.NUMBER) {
-    metadata.submittedAt = BigInt.fromString(submittedAtValue.toBigInt().toString());
+    let raw = submittedAtValue.toF64().toString();
+    let dotIndex = raw.indexOf(".");
+    if (dotIndex >= 0) {
+      raw = raw.substring(0, dotIndex);
+    }
+    metadata.submittedAt = BigInt.fromString(raw);
   }
 
   metadata.save();

--- a/pop-subgraph/tests/hat-metadata.test.ts
+++ b/pop-subgraph/tests/hat-metadata.test.ts
@@ -310,17 +310,12 @@ describe("HatMetadata IPFS Handler", () => {
     assert.fieldEquals("HatMetadata", ipfsHash, "hat", hatEntityId);
   });
 
-  test("Updates Hat.name from IPFS metadata when Hat has no name", () => {
+  test("Does not modify Hat entity from IPFS handler (avoids causality region conflict)", () => {
     let metadataCID = Bytes.fromHexString("0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd");
     let ipfsHash = bytes32ToCid(metadataCID);
     let hatEntityId = "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-1001";
 
     createMockHat(hatEntityId);
-
-    // Verify Hat has no name initially
-    let hatBefore = Hat.load(hatEntityId);
-    assert.assertNotNull(hatBefore);
-    assert.assertNull(hatBefore!.name);
 
     let context = new DataSourceContext();
     context.setString("hatEntityId", hatEntityId);
@@ -331,41 +326,13 @@ describe("HatMetadata IPFS Handler", () => {
 
     handleHatMetadata(contentBytes);
 
-    // Verify Hat.name was updated
+    // HatMetadata should have the name from IPFS
+    assert.fieldEquals("HatMetadata", ipfsHash, "name", "Treasury Manager");
+
+    // Hat entity should NOT be modified by the IPFS handler
     let hatAfter = Hat.load(hatEntityId);
     assert.assertNotNull(hatAfter);
-    assert.stringEquals(hatAfter!.name!, "Treasury Manager");
-  });
-
-  test("Does NOT update Hat.name from IPFS when Hat already has a name", () => {
-    let metadataCID = Bytes.fromHexString("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee");
-    let ipfsHash = bytes32ToCid(metadataCID);
-    let hatEntityId = "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-1001";
-
-    createMockHat(hatEntityId);
-
-    // Set an existing name on the Hat
-    let hat = Hat.load(hatEntityId)!;
-    hat.name = "Existing Role Name";
-    hat.save();
-
-    let context = new DataSourceContext();
-    context.setString("hatEntityId", hatEntityId);
-    dataSourceMock.setAddressAndContext(ipfsHash, context);
-
-    // IPFS has a different name
-    let jsonContent = '{"name": "New Name From IPFS"}';
-    let contentBytes = Bytes.fromUTF8(jsonContent);
-
-    handleHatMetadata(contentBytes);
-
-    // Verify Hat.name was NOT changed (existing name preserved)
-    let hatAfter = Hat.load(hatEntityId);
-    assert.assertNotNull(hatAfter);
-    assert.stringEquals(hatAfter!.name!, "Existing Role Name");
-
-    // But HatMetadata should still have the IPFS name
-    assert.fieldEquals("HatMetadata", ipfsHash, "name", "New Name From IPFS");
+    assert.assertNull(hatAfter!.name);
   });
 
   test("Handles empty name string as null", () => {


### PR DESCRIPTION
## Summary
- **Root cause fix**: Removed `Hat` entity mutation from the `handleHatMetadata` IPFS file data source handler. This was writing to an entity owned by the ethereum event causality region, causing a deterministic "Failed to transact block operations" / "WASM runtime thread terminated" abort during org deployment blocks (145+ triggers).
- Added missing duplicate check (`HatMetadata.load()`) in `createHatIpfsDataSource` to follow the 3-check IPFS pattern and prevent redundant file data sources.
- Fixed `toBigInt()` crash risk in `proposal-metadata.ts` and `token-request-metadata.ts` — JSON numbers with decimals (e.g. `1706812800.0`) now safely truncate before BigInt parsing.

## Test plan
- [x] `npm run codegen` passes
- [x] `npm run build` passes
- [x] All 241 tests pass
- [ ] Redeploy subgraph and verify it indexes past the previously failing block

🤖 Generated with [Claude Code](https://claude.com/claude-code)