### PR TITLE
fix: add missing duplicate checks to all IPFS data source callers

### DIFF
--- a/pop-subgraph/src/education-hub.ts
+++ b/pop-subgraph/src/education-hub.ts
@@ -18,6 +18,7 @@ import {
 import {
   EducationHubContract,
   EducationModule,
+  EducationModuleMetadata,
   ModuleCompletion,
   ModuleUpdate,
   HatPermission,
@@ -51,6 +52,13 @@ function createEducationModuleMetadataSource(contentHash: Bytes, moduleEntityId:
   }
 
   let ipfsCid = bytes32ToCid(contentHash);
+
+  // EducationModuleMetadata is immutable — skip if already indexed to prevent
+  // duplicate INSERT conflicts when the same CID triggers multiple times
+  let existing = EducationModuleMetadata.load(ipfsCid);
+  if (existing != null) {
+    return;
+  }
 
   let context = new DataSourceContext();
   context.setString("moduleEntityId", moduleEntityId);

--- a/pop-subgraph/src/org-registry.ts
+++ b/pop-subgraph/src/org-registry.ts
@@ -10,6 +10,7 @@ import {
   OrgRegistryContract,
   Organization,
   OrgMetaUpdate,
+  OrgMetadata,
   RegisteredContract,
   SwitchableBeaconContract
 } from "../generated/schema";
@@ -59,13 +60,17 @@ function createIpfsDataSource(metadataHash: Bytes, orgId: Bytes): void {
   // Convert bytes32 sha256 digest to IPFS CIDv0 string
   let ipfsCid = bytes32ToCid(metadataHash);
 
+  // Skip if metadata already indexed (prevents duplicate IPFS data sources
+  // which would cause INSERT conflicts for immutable OrgMetadataLink children)
+  let existing = OrgMetadata.load(ipfsCid);
+  if (existing != null) {
+    return;
+  }
+
   // Create context to pass orgId to the IPFS handler
   let context = new DataSourceContext();
   context.setBytes("orgId", orgId);
 
-  // Create the file data source with context
-  // If IPFS is unavailable or slow, this will be retried automatically
-  // and won't block the main chain indexing
   OrgMetadataTemplate.createWithContext(ipfsCid, context);
 }
 

--- a/pop-subgraph/src/participation-token.ts
+++ b/pop-subgraph/src/participation-token.ts
@@ -15,6 +15,7 @@ import {
   ParticipationTokenContract,
   HatPermission,
   TokenRequest,
+  TokenRequestMetadata,
   TokenBalance
 } from "../generated/schema";
 import { getOrCreateRole, loadExistingUser } from "./utils";
@@ -218,10 +219,14 @@ export function handleRequested(event: RequestedEvent): void {
   if (ipfsCid.length > 0) {
     tokenRequest.metadata = ipfsCid;
 
-    let context = new DataSourceContext();
-    context.setBigInt("timestamp", event.block.timestamp);
+    // TokenRequestMetadata is immutable — skip if already indexed
+    let existingMeta = TokenRequestMetadata.load(ipfsCid);
+    if (existingMeta == null) {
+      let context = new DataSourceContext();
+      context.setBigInt("timestamp", event.block.timestamp);
 
-    TokenRequestMetadataTemplate.createWithContext(ipfsCid, context);
+      TokenRequestMetadataTemplate.createWithContext(ipfsCid, context);
+    }
   }
 
   tokenRequest.save();

--- a/pop-subgraph/src/task-manager.ts
+++ b/pop-subgraph/src/task-manager.ts
@@ -29,6 +29,7 @@ import {
   ProjectCapChange,
   BountyCapChange,
   TaskMetadata,
+  TaskApplicationMetadata,
   ProjectMetadata,
   TaskRejection
 } from "../generated/schema";
@@ -421,10 +422,14 @@ export function handleTaskApplicationSubmitted(event: TaskApplicationSubmitted):
     let applicationCid = bytes32ToCid(event.params.applicationHash);
     application.metadata = applicationCid;
 
-    let context = new DataSourceContext();
-    context.setBigInt("timestamp", event.block.timestamp);
+    // TaskApplicationMetadata is immutable — skip if already indexed
+    let existingAppMeta = TaskApplicationMetadata.load(applicationCid);
+    if (existingAppMeta == null) {
+      let context = new DataSourceContext();
+      context.setBigInt("timestamp", event.block.timestamp);
 
-    TaskApplicationMetadataTemplate.createWithContext(applicationCid, context);
+      TaskApplicationMetadataTemplate.createWithContext(applicationCid, context);
+    }
   }
 
   application.save();

--- a/pop-subgraph/src/universal-account-registry.ts
+++ b/pop-subgraph/src/universal-account-registry.ts
@@ -12,6 +12,7 @@ import {
 import {
   UniversalAccountRegistry,
   Account,
+  AccountMetadata,
   UsernameChange,
   AccountDeletion,
   BatchRegistration,
@@ -272,8 +273,11 @@ export function handleProfileMetadataUpdated(event: ProfileMetadataUpdatedEvent)
   account.metadata = ipfsCid;
   account.save();
 
-  // Create IPFS file data source to fetch and parse the metadata
-  let context = new DataSourceContext();
-  context.setBytes("userAddress", userAddress);
-  AccountMetadataTemplate.createWithContext(ipfsCid, context);
+  // Skip creating IPFS data source if metadata already indexed
+  let existingMeta = AccountMetadata.load(ipfsCid);
+  if (existingMeta == null) {
+    let context = new DataSourceContext();
+    context.setBytes("userAddress", userAddress);
+    AccountMetadataTemplate.createWithContext(ipfsCid, context);
+  }
 }


### PR DESCRIPTION
## Summary
- Five IPFS data source callers were missing existence checks before `createWithContext`, allowing duplicate data sources for the same CID in the same block
- When duplicate handlers fire for immutable entities, both try to INSERT the same entity ID, crashing the indexer with "Failed to transact block operations" / WASM thread termination
- Added duplicate checks in: `org-registry.ts` (OrgMetadata/OrgMetadataLink), `education-hub.ts` (EducationModuleMetadata), `participation-token.ts` (TokenRequestMetadata), `task-manager.ts` (TaskApplicationMetadata), `universal-account-registry.ts` (AccountMetadata)

This completes the pattern already used by `hybrid-voting.ts`, `direct-democracy-voting.ts`, `eligibility-module.ts`, `task-manager.ts` (TaskMetadata/ProjectMetadata) — all IPFS data source callers now check before creating.

## Test plan
- [x] `npm run codegen` passes
- [x] `npm run build` passes
- [x] All 241 tests pass
- [x] `subgraph-lint` passes (0 errors)
- [ ] Redeploy subgraph and verify it indexes past the previously failing block

🤖 Generated with [Claude Code](https://claude.com/claude-code)