### PR TITLE
fix: remove entity type overlaps causing causality region conflicts

### DIFF
--- a/pop-subgraph/src/project-metadata.ts
+++ b/pop-subgraph/src/project-metadata.ts
@@ -1,5 +1,5 @@
 import { Bytes, dataSource, json, BigInt, JSONValueKind } from "@graphprotocol/graph-ts";
-import { ProjectMetadata, Project } from "../generated/schema";
+import { ProjectMetadata } from "../generated/schema";
 
 /**
  * Handler for IPFS file data source that parses project metadata JSON.

--- a/pop-subgraph/subgraph.yaml
+++ b/pop-subgraph/subgraph.yaml
@@ -901,7 +901,6 @@ templates:
       handler: handleTaskMetadata
       entities:
         - TaskMetadata
-        - Task
       abis:
         - name: TaskManager
           file: ./abis/TaskManager.json
@@ -915,7 +914,6 @@ templates:
       handler: handleProjectMetadata
       entities:
         - ProjectMetadata
-        - Project
       abis:
         - name: TaskManager
           file: ./abis/TaskManager.json
@@ -929,8 +927,6 @@ templates:
       handler: handleProposalMetadata
       entities:
         - ProposalMetadata
-        - Proposal
-        - DDVProposal
       abis:
         - name: HybridVoting
           file: ./abis/HybridVoting.json
@@ -944,7 +940,6 @@ templates:
       handler: handleEducationModuleMetadata
       entities:
         - EducationModuleMetadata
-        - EducationModule
       abis:
         - name: EducationHub
           file: ./abis/EducationHub.json


### PR DESCRIPTION
## Summary
- Four file/ipfs data source templates declared entity types (Task, Project, Proposal, DDVProposal, EducationModule) they never write to — but that ARE written by onchain ethereum event handlers in the same block
- In specVersion 1.2.0, file data sources run in a separate offchain causality region. When their `entities` list overlaps with onchain handler entity types, the store detects causality region conflicts during block transaction commit
- This caused non-deterministic "WASM runtime thread terminated" / "Failed to transact block operations" crashes — the failure point shifted each retry because IPFS fetch order varies
- Fix: restrict each file data source's `entities` list to only the metadata entity type the handler actually writes to

## Why previous fixes didn't work
- PR #161 (handler causality fix) and #162 (immutable entity pattern) fixed real issues but didn't address the yaml-level entity overlap
- PR #163 (duplicate data source checks) added good defensive checks, but the Graph node already prevents duplicate runtime hosts (the warnings), so the root cause was elsewhere
- The key evidence: **non-deterministic failure point** + **5 WASM threads killed simultaneously** pointed to a block-transaction-level conflict, not a handler-level bug

## Test plan
- [x] `npm run codegen` passes
- [x] `npm run build` passes
- [x] All 241 tests pass
- [x] `subgraph-lint` passes (0 errors)
- [ ] Redeploy and verify indexing past the previously failing block

🤖 Generated with [Claude Code](https://claude.com/claude-code)