### PR TITLE
fix: use unique proposal-based IDs for ProposalMetadata entities

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -1717,7 +1717,7 @@ If IPFS content is unavailable (404), this entity won't be created and the propo
 reference will point to a non-existent entity (queries will return null).
 """
 type ProposalMetadata @entity(immutable: true) {
-  id: String! # IPFS CID (Qm...)
+  id: String! # Proposal entity ID (contractAddress-proposalId)
   description: String! # Full proposal description text
   optionNames: [String!]! # Names for each voting option
   createdAt: BigInt # Timestamp from IPFS metadata

--- a/pop-subgraph/src/direct-democracy-voting.ts
+++ b/pop-subgraph/src/direct-democracy-voting.ts
@@ -59,8 +59,10 @@ function createProposalMetadataDataSource(descriptionHash: Bytes, proposalEntity
   // Convert bytes32 to IPFS CIDv0
   let ipfsCid = bytes32ToCid(descriptionHash);
 
-  // Skip if ProposalMetadata already exists - prevents duplicate file data sources
-  let existingMetadata = ProposalMetadata.load(ipfsCid);
+  // Use proposalEntityId as the metadata entity ID (not CID) so each proposal
+  // gets its own immutable entity — avoids INSERT conflicts when the same CID
+  // is reused across proposals in different blocks (offchain causality regions)
+  let existingMetadata = ProposalMetadata.load(proposalEntityId);
   if (existingMetadata != null) {
     return;
   }
@@ -340,10 +342,9 @@ export function handleNewProposal(event: NewProposal): void {
   proposal.createdAtBlock = event.block.number;
   proposal.transactionHash = event.transaction.hash;
 
-  // Set metadata link - entity will be created by IPFS handler if content exists
+  // Link metadata by proposalId (not CID) — each proposal gets its own metadata entity
   if (!event.params.descriptionHash.equals(ZERO_HASH)) {
-    let metadataCid = bytes32ToCid(event.params.descriptionHash);
-    proposal.metadata = metadataCid;
+    proposal.metadata = proposalId;
   }
 
   proposal.save();
@@ -376,10 +377,9 @@ export function handleNewHatProposal(event: NewHatProposal): void {
   proposal.createdAtBlock = event.block.number;
   proposal.transactionHash = event.transaction.hash;
 
-  // Set metadata link - entity will be created by IPFS handler if content exists
+  // Link metadata by proposalId (not CID)
   if (!event.params.descriptionHash.equals(ZERO_HASH)) {
-    let metadataCid = bytes32ToCid(event.params.descriptionHash);
-    proposal.metadata = metadataCid;
+    proposal.metadata = proposalId;
   }
 
   proposal.save();

--- a/pop-subgraph/src/hybrid-voting.ts
+++ b/pop-subgraph/src/hybrid-voting.ts
@@ -59,8 +59,10 @@ function createProposalMetadataDataSource(descriptionHash: Bytes, proposalEntity
   // Convert bytes32 to IPFS CIDv0
   let ipfsCid = bytes32ToCid(descriptionHash);
 
-  // Skip if ProposalMetadata already exists - prevents duplicate file data sources
-  let existingMetadata = ProposalMetadata.load(ipfsCid);
+  // Use proposalEntityId as the metadata entity ID (not CID) so each proposal
+  // gets its own immutable entity — avoids INSERT conflicts when the same CID
+  // is reused across proposals in different blocks (offchain causality regions)
+  let existingMetadata = ProposalMetadata.load(proposalEntityId);
   if (existingMetadata != null) {
     return;
   }
@@ -304,12 +306,9 @@ export function handleNewProposal(event: NewProposal): void {
   proposal.createdAtBlock = event.block.number;
   proposal.transactionHash = event.transaction.hash;
 
-  // Set metadata link - entity will be created by IPFS handler if content exists
-  // Note: We don't create a stub here because file data sources run in a separate causality
-  // region, and both would try to Insert in the same block causing conflicts.
+  // Link metadata by proposalId (not CID) — each proposal gets its own metadata entity
   if (!event.params.descriptionHash.equals(ZERO_HASH)) {
-    let metadataCid = bytes32ToCid(event.params.descriptionHash);
-    proposal.metadata = metadataCid;
+    proposal.metadata = proposalId;
   }
 
   proposal.save();
@@ -361,10 +360,9 @@ export function handleNewHatProposal(event: NewHatProposal): void {
   proposal.createdAtBlock = event.block.number;
   proposal.transactionHash = event.transaction.hash;
 
-  // Set metadata link - entity will be created by IPFS handler if content exists
+  // Link metadata by proposalId (not CID)
   if (!event.params.descriptionHash.equals(ZERO_HASH)) {
-    let metadataCid = bytes32ToCid(event.params.descriptionHash);
-    proposal.metadata = metadataCid;
+    proposal.metadata = proposalId;
   }
 
   proposal.save();

--- a/pop-subgraph/src/proposal-metadata.ts
+++ b/pop-subgraph/src/proposal-metadata.ts
@@ -12,28 +12,29 @@ import { ProposalMetadata } from "../generated/schema";
  * }
  *
  * ProposalMetadata is immutable — the entity store only allows INSERT, not UPDATE.
- * This handler follows the single-path pattern: one existence check at the top,
- * one entity creation, one save. Multiple code paths with separate load/new/save
- * cycles cause INSERT conflicts when the same CID is triggered more than once
- * in the same block.
+ * Uses proposalEntityId (from DataSourceContext) as the entity ID instead of CID,
+ * so each proposal gets its own metadata entity. This avoids INSERT conflicts when
+ * two proposals share the same CID but land in different blocks (which run in
+ * separate offchain causality regions in specVersion >= 1.0.0).
  */
 export function handleProposalMetadata(content: Bytes): void {
-  let ipfsCid = dataSource.stringParam();
+  let context = dataSource.context();
+  let proposalEntityId = context.getString("proposalEntityId");
 
   // Immutable — skip if already exists
-  let existing = ProposalMetadata.load(ipfsCid);
+  let existing = ProposalMetadata.load(proposalEntityId);
   if (existing != null) {
     return;
   }
 
-  let metadata = new ProposalMetadata(ipfsCid);
+  let metadata = new ProposalMetadata(proposalEntityId);
   metadata.description = "";
   metadata.optionNames = [];
 
   // Try to parse the JSON content
   let jsonResult = json.try_fromBytes(content);
   if (jsonResult.isError) {
-    log.warning("[ProposalMetadata] Failed to parse JSON for CID: {}", [ipfsCid]);
+    log.warning("[ProposalMetadata] Failed to parse JSON for proposal: {}", [proposalEntityId]);
     metadata.save();
     return;
   }


### PR DESCRIPTION
## Summary
- Uses the proposal entity ID (`contractAddress-proposalId`) instead of the IPFS CID as the `ProposalMetadata` entity ID, so each proposal gets its own immutable metadata entity
- Fixes the indexer crash at block 45679972 on gnosis caused by two proposals (55 and 56) sharing the same IPFS CID — in specVersion >= 1.0.0, each block's file data source handler runs in a separate offchain causality region and can't see entities from other blocks, causing a duplicate INSERT on the immutable entity
- Applied consistently across `hybrid-voting.ts`, `direct-democracy-voting.ts`, and `proposal-metadata.ts`

## Test plan
- [x] `npm run codegen` passes
- [x] `npm run build` passes
- [x] All 241 tests pass
- [x] `subgraph-lint` — 0 errors (7 pre-existing warnings)
- [ ] Deploy to gnosis and verify indexer syncs past block 45679972

🤖 Generated with [Claude Code](https://claude.com/claude-code)