### PR TITLE
feat: add useTokenSymbol to OrgMetadata

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -1689,6 +1689,10 @@ type OrgMetadata @entity(immutable: false) {
   backgroundColor: String
   logo: String # IPFS CID of the org logo image
   hideTreasury: Boolean # If true, treasury section is hidden in the UI
+  # When true, UI labels participation-token amounts using the token's
+  # actual symbol (e.g. "REP") instead of the default "Shares". Stored
+  # nullable so missing/old metadata defaults to "Shares" client-side.
+  useTokenSymbol: Boolean
   links: [OrgMetadataLink!]! @derivedFrom(field: "metadata")
   indexedAt: BigInt
 }

--- a/pop-subgraph/src/org-metadata.ts
+++ b/pop-subgraph/src/org-metadata.ts
@@ -12,6 +12,7 @@ import { OrgMetadata, OrgMetadataLink } from "../generated/schema";
  *   backgroundColor: "#1a1a2e" // optional CSS color or gradient string
  *   logo: "QmXxx...",         // optional IPFS CID
  *   hideTreasury: true/false  // optional, defaults to null (= show treasury)
+ *   useTokenSymbol: false     // optional, defaults to null/false
  * }
  *
  * This handler is resilient to malformed data - if parsing fails or fields
@@ -84,6 +85,17 @@ export function handleOrgMetadata(content: Bytes): void {
     let hideTreasuryValue = jsonObject.get("hideTreasury");
     if (hideTreasuryValue != null && !hideTreasuryValue.isNull() && hideTreasuryValue.kind == JSONValueKind.BOOL) {
       metadata.hideTreasury = hideTreasuryValue.toBool();
+    }
+
+    // Parse useTokenSymbol — opts the org out of the default "Shares" label
+    // in favour of the live participation-token symbol. Field is optional;
+    // if missing/null, frontend treats it as false.
+    let useTokenSymbolValue = jsonObject.get("useTokenSymbol");
+    if (
+      useTokenSymbolValue != null && !useTokenSymbolValue.isNull() &&
+      useTokenSymbolValue.kind == JSONValueKind.BOOL
+    ) {
+      metadata.useTokenSymbol = useTokenSymbolValue.toBool();
     }
 
     // Set indexed timestamp (approximate - file data sources don't have block context)


### PR DESCRIPTION
## Summary

Adds an optional `useTokenSymbol: Boolean` field to `OrgMetadata` so the frontend can render the participation-token's actual symbol (e.g. "REP") instead of the hardcoded "Shares" default in leaderboards, task cards, profile balances, etc.

## Why

Pairs with the new ParticipationToken `setName` / `setSymbol` governance proposals (separate contracts PR). When an org renames its token via governance, they probably want the UI to reflect that. Today every "shares" label is hardcoded.

This is an **opt-in switch**:
- `useTokenSymbol: true` → UI displays `participationToken.symbol()`
- `useTokenSymbol: false` / missing / null → UI keeps "Shares" (existing behavior, no migration needed for legacy orgs)

## Changes

- **`schema.graphql`** — add nullable `useTokenSymbol: Boolean` to `OrgMetadata`. Nullable so old metadata files without the key still parse cleanly.
- **`src/org-metadata.ts`** — parse the field with the same null-safety pattern as `description` / `template`.

## Verification

- [x] `graph codegen` regenerates types cleanly
- [x] `graph build` succeeds
- [ ] Once deployed, query an org's metadata and verify `useTokenSymbol` returns null for old metadata, true/false for new uploads.

## Pairs with
- contracts: `feat: add executor-gated setName/setSymbol to ParticipationToken`
- frontend: PR adding the metadata-editor toggle + label-resolution helper (forthcoming)