### PR TITLE
fix: index ParticipationToken name + symbol changes

### DIFF
--- a/pop-subgraph/abis/ParticipationToken.json
+++ b/pop-subgraph/abis/ParticipationToken.json
@@ -699,6 +699,32 @@
   },
   {
     "type": "function",
+    "name": "setName",
+    "inputs": [
+      {
+        "name": "newName",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setSymbol",
+    "inputs": [
+      {
+        "name": "newSymbol",
+        "type": "string",
+        "internalType": "string"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "setTaskManager",
     "inputs": [
       {
@@ -968,6 +994,19 @@
   },
   {
     "type": "event",
+    "name": "NameSet",
+    "inputs": [
+      {
+        "name": "newName",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "RequestApproved",
     "inputs": [
       {
@@ -1028,6 +1067,19 @@
       },
       {
         "name": "ipfsHash",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SymbolSet",
+    "inputs": [
+      {
+        "name": "newSymbol",
         "type": "string",
         "indexed": false,
         "internalType": "string"
@@ -1213,6 +1265,11 @@
   },
   {
     "type": "error",
+    "name": "EmptyString",
+    "inputs": []
+  },
+  {
+    "type": "error",
     "name": "InvalidAccountNonce",
     "inputs": [
       {
@@ -1287,6 +1344,11 @@
         "internalType": "uint256"
       }
     ]
+  },
+  {
+    "type": "error",
+    "name": "StringTooLong",
+    "inputs": []
   },
   {
     "type": "error",

--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -1689,6 +1689,10 @@ type OrgMetadata @entity(immutable: false) {
   backgroundColor: String
   logo: String # IPFS CID of the org logo image
   hideTreasury: Boolean # If true, treasury section is hidden in the UI
+  # When true, UI labels participation-token amounts using the token's
+  # actual symbol (e.g. "REP") instead of the default "Shares". Stored
+  # nullable so missing/old metadata defaults to "Shares" client-side.
+  useTokenSymbol: Boolean
   links: [OrgMetadataLink!]! @derivedFrom(field: "metadata")
   indexedAt: BigInt
 }

--- a/pop-subgraph/src/org-metadata.ts
+++ b/pop-subgraph/src/org-metadata.ts
@@ -12,6 +12,7 @@ import { OrgMetadata, OrgMetadataLink } from "../generated/schema";
  *   backgroundColor: "#1a1a2e" // optional CSS color or gradient string
  *   logo: "QmXxx...",         // optional IPFS CID
  *   hideTreasury: true/false  // optional, defaults to null (= show treasury)
+ *   useTokenSymbol: false     // optional, defaults to null/false
  * }
  *
  * This handler is resilient to malformed data - if parsing fails or fields
@@ -84,6 +85,17 @@ export function handleOrgMetadata(content: Bytes): void {
     let hideTreasuryValue = jsonObject.get("hideTreasury");
     if (hideTreasuryValue != null && !hideTreasuryValue.isNull() && hideTreasuryValue.kind == JSONValueKind.BOOL) {
       metadata.hideTreasury = hideTreasuryValue.toBool();
+    }
+
+    // Parse useTokenSymbol — opts the org out of the default "Shares" label
+    // in favour of the live participation-token symbol. Field is optional;
+    // if missing/null, frontend treats it as false.
+    let useTokenSymbolValue = jsonObject.get("useTokenSymbol");
+    if (
+      useTokenSymbolValue != null && !useTokenSymbolValue.isNull() &&
+      useTokenSymbolValue.kind == JSONValueKind.BOOL
+    ) {
+      metadata.useTokenSymbol = useTokenSymbolValue.toBool();
     }
 
     // Set indexed timestamp (approximate - file data sources don't have block context)

--- a/pop-subgraph/src/participation-token.ts
+++ b/pop-subgraph/src/participation-token.ts
@@ -1,6 +1,7 @@
 import { BigInt, Bytes, log, Address, DataSourceContext } from "@graphprotocol/graph-ts";
 import { TokenRequestMetadata as TokenRequestMetadataTemplate } from "../generated/templates";
 import {
+  ParticipationToken as ParticipationTokenAbi,
   Initialized as InitializedEvent,
   Transfer as TransferEvent,
   MemberHatSet as MemberHatSetEvent,
@@ -9,7 +10,9 @@ import {
   RequestApproved as RequestApprovedEvent,
   RequestCancelled as RequestCancelledEvent,
   TaskManagerSet as TaskManagerSetEvent,
-  EducationHubSet as EducationHubSetEvent
+  EducationHubSet as EducationHubSetEvent,
+  NameSet as NameSetEvent,
+  SymbolSet as SymbolSetEvent
 } from "../generated/templates/ParticipationToken/ParticipationToken";
 import {
   ParticipationTokenContract,
@@ -23,9 +26,11 @@ import { getOrCreateRole, loadExistingUser } from "./utils";
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
 export function handleInitialized(event: InitializedEvent): void {
-  // Initialization is handled by OrgDeployer when the contract is created.
-  // Initial values for name, symbol, executor, hats will be populated there.
-  // We avoid contract calls here to support non-archive RPC nodes.
+  // Hydrate name + symbol from the freshly initialized token. Graph node
+  // permits current-state try_* contract calls on non-archive RPCs; only
+  // historical block-pinned reads require archive nodes. Without this,
+  // ParticipationTokenContract.{name,symbol} stays as the empty strings
+  // seeded by org-deployer.ts and the UI falls back to "Shares" forever.
   let contract = ParticipationTokenContract.load(event.address);
   if (contract == null) {
     log.warning("ParticipationTokenContract not found at address {}", [
@@ -33,7 +38,15 @@ export function handleInitialized(event: InitializedEvent): void {
     ]);
     return;
   }
-  // Just save to mark initialization
+  let bound = ParticipationTokenAbi.bind(event.address);
+  let nameResult = bound.try_name();
+  if (!nameResult.reverted) {
+    contract.name = nameResult.value;
+  }
+  let symbolResult = bound.try_symbol();
+  if (!symbolResult.reverted) {
+    contract.symbol = symbolResult.value;
+  }
   contract.save();
 }
 
@@ -294,5 +307,29 @@ export function handleEducationHubSet(event: EducationHubSetEvent): void {
   }
 
   contract.educationHubAddress = event.params.educationHub;
+  contract.save();
+}
+
+export function handleNameSet(event: NameSetEvent): void {
+  let contract = ParticipationTokenContract.load(event.address);
+  if (contract == null) {
+    log.warning("ParticipationTokenContract not found at address {}", [
+      event.address.toHexString()
+    ]);
+    return;
+  }
+  contract.name = event.params.newName;
+  contract.save();
+}
+
+export function handleSymbolSet(event: SymbolSetEvent): void {
+  let contract = ParticipationTokenContract.load(event.address);
+  if (contract == null) {
+    log.warning("ParticipationTokenContract not found at address {}", [
+      event.address.toHexString()
+    ]);
+    return;
+  }
+  contract.symbol = event.params.newSymbol;
   contract.save();
 }

--- a/pop-subgraph/subgraph.yaml
+++ b/pop-subgraph/subgraph.yaml
@@ -555,6 +555,10 @@ templates:
           handler: handleTaskManagerSet
         - event: EducationHubSet(indexed address)
           handler: handleEducationHubSet
+        - event: NameSet(string)
+          handler: handleNameSet
+        - event: SymbolSet(string)
+          handler: handleSymbolSet
       file: ./src/participation-token.ts
   - kind: ethereum
     name: QuickJoin


### PR DESCRIPTION
Frontend PR #364 wired up a useTokenSymbol org-metadata flag, but org.participationToken.symbol was always empty.

Root cause: handleInitialized skipped contract calls and there were no handlers for the new NameSet / SymbolSet events shipped in contracts b27ce4b0.

Changes:
- abis/ParticipationToken.json synced from contracts repo (adds NameSet, SymbolSet)
- subgraph.yaml: PT template subscribes to NameSet and SymbolSet
- handleInitialized now hydrates name + symbol via try_name() / try_symbol()
- New handleNameSet / handleSymbolSet write event payloads onto the entity

Verified: yarn codegen + yarn build clean. After redeploy + reindex, Test6 should surface symbol = KUBIX.