### PR TITLE
fix: drive User.currentHatIds off Hats TransferSingle (closes #166)

### DIFF
--- a/pop-subgraph/abis/Hats.json
+++ b/pop-subgraph/abis/Hats.json
@@ -1,0 +1,35 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "operator", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "id", "type": "uint256" },
+      { "indexed": false, "internalType": "uint256", "name": "value", "type": "uint256" }
+    ],
+    "name": "TransferSingle",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "operator", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "from", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "to", "type": "address" },
+      { "indexed": false, "internalType": "uint256[]", "name": "ids", "type": "uint256[]" },
+      { "indexed": false, "internalType": "uint256[]", "name": "values", "type": "uint256[]" }
+    ],
+    "name": "TransferBatch",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "uint256", "name": "hatId", "type": "uint256" },
+      { "indexed": false, "internalType": "bool", "name": "newStatus", "type": "bool" }
+    ],
+    "name": "HatStatusChanged",
+    "type": "event"
+  }
+]

--- a/pop-subgraph/networks.json
+++ b/pop-subgraph/networks.json
@@ -15,6 +15,10 @@
     "PoaManagerSatellite": {
       "address": "0x0000000000000000000000000000000000000000",
       "startBlock": 447059849
+    },
+    "Hats": {
+      "address": "0x3bc1A0Ad72417f2d411118085256fC53CBdDd137",
+      "startBlock": 447059849
     }
   },
   "gnosis": {
@@ -33,6 +37,10 @@
     "PoaManagerSatellite": {
       "address": "0x4Ad70029a9247D369a5bEA92f90840B9ee58eD06",
       "startBlock": 45408030
+    },
+    "Hats": {
+      "address": "0x3bc1A0Ad72417f2d411118085256fC53CBdDd137",
+      "startBlock": 45407962
     }
   }
 }

--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -666,6 +666,11 @@ type RoleWearer @entity(immutable: false) {
   addedAt: BigInt!
   addedAtBlock: BigInt!
   removedAt: BigInt
+  # True iff the wearer currently holds a positive Hats Protocol ERC-1155
+  # balance for the hat (tracked via TransferSingle). Note: this does NOT
+  # incorporate Hat.active or wearer-standing — Hats.isWearerOfHat semantics
+  # require ANDing this flag with Hat.active and (if vouching is configured)
+  # the linked WearerEligibility.eligible/standing.
   isActive: Boolean!
   transactionHash: Bytes!
 }

--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -610,6 +610,11 @@ type Hat @entity(immutable: false) {
   metadata: HatMetadata # Link to IPFS-indexed metadata content
   metadataUpdatedAt: BigInt
   metadataUpdatedAtBlock: BigInt
+  # Hats Protocol active flag — false means Hats.isWearerOfHat returns false
+  # for ALL wearers regardless of token balance. Tokens are NOT burned when a
+  # hat is toggled off, so consumers wanting "is this person wearing X?" must
+  # AND wearer-balance with this flag.
+  active: Boolean!
   createdAt: BigInt!
   createdAtBlock: BigInt!
   transactionHash: Bytes!
@@ -663,6 +668,19 @@ type RoleWearer @entity(immutable: false) {
   removedAt: BigInt
   isActive: Boolean!
   transactionHash: Bytes!
+}
+
+# HatLookup — global hatId → org/role index used by the Hats Protocol
+# TransferSingle handler. Hats events only carry the bare uint256 hatId;
+# we need to resolve which org / role / Hat entity that id belongs to in
+# our subgraph (without iterating). Populated whenever getOrCreateRole
+# creates or loads a Role.
+type HatLookup @entity(immutable: false) {
+  id: String! # hatId.toString()
+  hatId: BigInt!
+  organization: Organization!
+  role: Role!
+  hat: Hat
 }
 
 type WearerEligibility @entity(immutable: false) {

--- a/pop-subgraph/src/eligibility-module.ts
+++ b/pop-subgraph/src/eligibility-module.ts
@@ -45,7 +45,8 @@ import {
   linkWearerEligibilityToRoleWearer,
   updateRoleWearerStatus,
   recordUserHatChange,
-  shouldCreateRoleWearer
+  shouldCreateRoleWearer,
+  linkHatToLookup
 } from "./utils";
 
 /**
@@ -158,9 +159,11 @@ export function handleHatCreatedWithEligibility(
 
   hat.save();
 
-  // Link Hat to Role entity
+  // Link Hat to Role entity + populate HatLookup.hat so HatStatusChanged
+  // can resolve hatId -> Hat entity.
   if (eligibilityModule) {
     linkHatToRole(eligibilityModule.organization, hatId, hatEntityId, event);
+    linkHatToLookup(hatId, eligibilityModule.organization, hatEntityId);
   }
 }
 
@@ -375,6 +378,14 @@ export function handleDefaultEligibilityUpdated(
     hat.createdAtBlock = event.block.number;
     hat.transactionHash = event.transaction.hash;
     hat.save();
+
+    // Populate HatLookup.hat so Hats.HatStatusChanged can resolve hatId
+    // -> Hat entity. Org comes from the eligibility module that fired this
+    // event.
+    let elig = EligibilityModuleContract.load(contractAddress);
+    if (elig) {
+      linkHatToLookup(hatId, elig.organization, hatEntityId);
+    }
 
     log.info("Created Hat entity from DefaultEligibilityUpdated for hatId {} at contract {}", [
       hatId.toString(),

--- a/pop-subgraph/src/eligibility-module.ts
+++ b/pop-subgraph/src/eligibility-module.ts
@@ -151,6 +151,7 @@ export function handleHatCreatedWithEligibility(
   hat.defaultEligible = event.params.defaultEligible;
   hat.defaultStanding = event.params.defaultStanding;
   hat.mintedCount = event.params.mintedCount;
+  hat.active = true; // default; updated by Hats.HatStatusChanged
   hat.createdAt = event.block.timestamp;
   hat.createdAtBlock = event.block.number;
   hat.transactionHash = event.transaction.hash;
@@ -240,17 +241,12 @@ export function handleWearerEligibilityUpdated(
       wearerEligibilityId
     );
 
-    // Update User.currentHatIds based on eligibility
-    let wearerUser = loadExistingUser(
-      eligibilityModule.organization,
-      wearer,
-      event.block.timestamp,
-      event.block.number
-    );
-    if (wearerUser) {
-      // Add or remove hat from currentHatIds based on active status
-      recordUserHatChange(wearerUser, hatId, isActive, event);
-    }
+    // NOTE: User.currentHatIds is no longer driven from eligibility events.
+    // Hats Protocol's ERC-1155 TransferSingle is the source of truth for who
+    // actually holds a hat token. Eligibility revokes that don't burn the
+    // token (e.g. vouching with combineWithHierarchy=true) used to silently
+    // drop wearers from the subgraph view; see issue #166. The eligibility
+    // view itself is preserved on the WearerEligibility entity.
   }
 }
 
@@ -338,17 +334,9 @@ export function handleBulkWearerEligibilityUpdated(
         wearerEligibilityId
       );
 
-      // Update User.currentHatIds based on eligibility
-      let wearerUser = loadExistingUser(
-        eligibilityModule.organization,
-        wearer,
-        event.block.timestamp,
-        event.block.number
-      );
-      if (wearerUser) {
-        // Add or remove hat from currentHatIds based on active status
-        recordUserHatChange(wearerUser, hatId, isActive, event);
-      }
+      // NOTE: User.currentHatIds is now driven by Hats.TransferSingle, not by
+      // BulkWearerEligibilityUpdated. See handleWearerEligibilityUpdated above
+      // and issue #166 for context.
     }
   }
 }
@@ -382,6 +370,7 @@ export function handleDefaultEligibilityUpdated(
     hat.defaultEligible = event.params.eligible;
     hat.defaultStanding = event.params.standing;
     hat.mintedCount = BigInt.fromI32(0); // Unknown - will be updated if minting events occur
+    hat.active = true; // default; updated by Hats.HatStatusChanged
     hat.createdAt = event.block.timestamp;
     hat.createdAtBlock = event.block.number;
     hat.transactionHash = event.transaction.hash;

--- a/pop-subgraph/src/hats.ts
+++ b/pop-subgraph/src/hats.ts
@@ -1,0 +1,109 @@
+// Hats Protocol event handlers — drive User.currentHatIds and RoleWearer.isActive
+// off the canonical ERC-1155 token state instead of the EligibilityModule's view.
+//
+// Why this exists: an org with combineWithHierarchy=true vouching can hold a hat
+// open to a wearer even after the EligibilityModule fires
+// WearerEligibilityUpdated(eligible=false). The token is NOT burned in that case,
+// so Hats.isWearerOfHat keeps returning true on-chain. Driving User.currentHatIds
+// off eligibility events undercounted wearers (issue #166).
+//
+// Source of truth: ERC-1155 TransferSingle / TransferBatch from the Hats Protocol
+// canonical contract.
+
+import { Address, BigInt, ethereum, log } from "@graphprotocol/graph-ts";
+import {
+  TransferSingle,
+  TransferBatch,
+  HatStatusChanged,
+} from "../generated/Hats/Hats";
+import { HatLookup, Hat } from "../generated/schema";
+import { applyHatTransferAdd, applyHatTransferRemove } from "./utils";
+
+const ZERO_ADDRESS = Address.zero();
+
+/**
+ * Apply a single hat transfer for one (hatId, value=1) tuple.
+ * Hats Protocol always uses value=1 per ERC-1155 token, but we accept any
+ * positive value defensively (multi-hat aggregations would still represent
+ * one logical hat).
+ */
+function applyTransfer(
+  from: Address,
+  to: Address,
+  hatId: BigInt,
+  value: BigInt,
+  event: ethereum.Event
+): void {
+  if (value.isZero()) return;
+
+  // Skip hats not registered to any of our orgs. Hats Protocol is global —
+  // we only care about hats in trees we deployed.
+  let lookup = HatLookup.load(hatId.toString());
+  if (lookup == null) return;
+  let orgId = lookup.organization;
+
+  let isMint = from.equals(ZERO_ADDRESS);
+  let isBurn = to.equals(ZERO_ADDRESS);
+
+  if (isMint && !isBurn) {
+    applyHatTransferAdd(orgId, to, hatId, event);
+  } else if (isBurn && !isMint) {
+    applyHatTransferRemove(orgId, from, hatId, event);
+  } else if (!isMint && !isBurn) {
+    // transferHat: move the slot from one wearer to another
+    applyHatTransferRemove(orgId, from, hatId, event);
+    applyHatTransferAdd(orgId, to, hatId, event);
+  }
+  // 0x0 -> 0x0 is undefined behavior in ERC-1155; ignore.
+}
+
+export function handleHatsTransferSingle(event: TransferSingle): void {
+  applyTransfer(
+    event.params.from,
+    event.params.to,
+    event.params.id,
+    event.params.value,
+    event
+  );
+}
+
+export function handleHatsTransferBatch(event: TransferBatch): void {
+  let ids = event.params.ids;
+  let values = event.params.values;
+  if (ids.length != values.length) {
+    log.warning(
+      "[Hats] TransferBatch ids/values length mismatch — ids={} values={} tx={}",
+      [
+        ids.length.toString(),
+        values.length.toString(),
+        event.transaction.hash.toHexString(),
+      ]
+    );
+    return;
+  }
+  for (let i = 0; i < ids.length; i++) {
+    applyTransfer(
+      event.params.from,
+      event.params.to,
+      ids[i],
+      values[i],
+      event
+    );
+  }
+}
+
+/**
+ * Mark a hat active or inactive in our subgraph. Tokens are NOT burned when a
+ * hat is toggled off, so consumers wanting "is X currently wearing this hat?"
+ * semantics must AND wearer-balance with Hat.active.
+ */
+export function handleHatsStatusChanged(event: HatStatusChanged): void {
+  let lookup = HatLookup.load(event.params.hatId.toString());
+  if (lookup == null) return;
+  let hatEntityId = lookup.hat;
+  if (hatEntityId == null) return;
+  let hat = Hat.load(hatEntityId as string);
+  if (hat == null) return;
+  hat.active = event.params.newStatus;
+  hat.save();
+}

--- a/pop-subgraph/src/hats.ts
+++ b/pop-subgraph/src/hats.ts
@@ -35,6 +35,11 @@ function applyTransfer(
   event: ethereum.Event
 ): void {
   if (value.isZero()) return;
+  // Self-transfer (from == to) is rejected by Hats Protocol but defend
+  // against it anyway: a remove+add for the same wearer with the same
+  // (txHash, logIndex, userId, hatId) would collide on the immutable
+  // UserHatChange entity ID and crash the indexer.
+  if (from.equals(to)) return;
 
   // Skip hats not registered to any of our orgs. Hats Protocol is global —
   // we only care about hats in trees we deployed.

--- a/pop-subgraph/src/utils.ts
+++ b/pop-subgraph/src/utils.ts
@@ -385,6 +385,37 @@ export function getOrCreateRole(
 }
 
 /**
+ * Ensure HatLookup.hat points at the given Hat entity. Called from the
+ * eligibility-module Hat creation sites so that Hats.HatStatusChanged can
+ * mark the hat active/inactive without the eligibility module having to
+ * fire a corresponding event.
+ *
+ * If HatLookup hasn't been created yet (no Role yet), we create a minimal
+ * lookup pointing at hat-only. The role link will be filled in once
+ * getOrCreateRole runs for this hatId.
+ */
+export function linkHatToLookup(
+  hatId: BigInt,
+  orgId: Bytes,
+  hatEntityId: string
+): void {
+  let lookupId = hatId.toString();
+  let lookup = HatLookup.load(lookupId);
+  if (lookup == null) {
+    lookup = new HatLookup(lookupId);
+    lookup.hatId = hatId;
+    lookup.organization = orgId;
+    // Role pointer required by schema. Populate with the canonical role id
+    // for this org+hat — getOrCreateRole will create the Role entity itself
+    // when a wearer is first observed; the dangling reference is fine in
+    // graph-node (entity refs aren't enforced as foreign keys).
+    lookup.role = orgId.toHexString() + "-" + hatId.toString();
+  }
+  lookup.hat = hatEntityId;
+  lookup.save();
+}
+
+/**
  * Apply a Hats Protocol token-state mint to (orgId, wearer, hatId).
  *
  * Treats this as the source of truth for "the wearer holds the hat token":

--- a/pop-subgraph/src/utils.ts
+++ b/pop-subgraph/src/utils.ts
@@ -11,6 +11,7 @@ import {
   Role,
   RoleWearer,
   Hat,
+  HatLookup,
   ExecutorContract,
   EligibilityModuleContract,
 } from "../generated/schema";
@@ -363,7 +364,190 @@ export function getOrCreateRole(
     role.save();
   }
 
+  // Maintain HatLookup so the Hats Protocol TransferSingle handler can resolve
+  // a bare hatId back to its org+role context. Idempotent: existing entries
+  // are updated only if the role pointer drifts.
+  let lookupId = hatId.toString();
+  let lookup = HatLookup.load(lookupId);
+  if (lookup == null) {
+    lookup = new HatLookup(lookupId);
+    lookup.hatId = hatId;
+    lookup.organization = orgId;
+    lookup.role = roleId;
+    lookup.save();
+  } else if (lookup.role != roleId) {
+    // Hat was previously seen under a different org's lookup — that should
+    // not happen since hat IDs are globally unique. Log via no-op (subgraph
+    // mappings can't `throw`); prefer existing entry.
+  }
+
   return role as Role;
+}
+
+/**
+ * Apply a Hats Protocol token-state mint to (orgId, wearer, hatId).
+ *
+ * Treats this as the source of truth for "the wearer holds the hat token":
+ *   - Adds hatId to User.currentHatIds (creates the User entity if missing,
+ *     using joinMethod="HatTransfer" to flag the unusual entry path).
+ *   - Reactivates the User if they had been marked Inactive.
+ *   - Upserts a RoleWearer with isActive = true.
+ *
+ * Idempotent: re-applying for an already-held hat is a no-op.
+ */
+export function applyHatTransferAdd(
+  orgId: Bytes,
+  wearer: Address,
+  hatId: BigInt,
+  event: ethereum.Event
+): void {
+  if (isSystemContract(orgId, wearer)) {
+    return;
+  }
+  let userId = orgId.toHexString() + "-" + wearer.toHexString();
+  let user = User.load(userId);
+  if (user == null) {
+    // First time we have seen this wallet for this org — they joined by
+    // having a hat directly minted/transferred onto them (governance grant,
+    // direct mint, etc.) rather than via QuickJoin/HatClaim.
+    user = new User(userId);
+    user.organization = orgId;
+    user.address = wearer;
+    user.participationTokenBalance = BigInt.fromI32(0);
+    user.totalVotes = BigInt.fromI32(0);
+    user.totalTasksCompleted = BigInt.fromI32(0);
+    user.totalTasksCancelled = BigInt.fromI32(0);
+    user.totalModulesCompleted = BigInt.fromI32(0);
+    user.totalClaimsAmount = BigInt.fromI32(0);
+    user.totalPaymentsAmount = BigInt.fromI32(0);
+    user.totalTokenRequestsAmount = BigInt.fromI32(0);
+    user.firstSeenAt = event.block.timestamp;
+    user.firstSeenAtBlock = event.block.number;
+    user.currentHatIds = [];
+    user.membershipStatus = "Active";
+    user.joinMethod = "HatTransfer";
+    user.account = wearer;
+  }
+
+  user.lastActiveAt = event.block.timestamp;
+  user.lastActiveAtBlock = event.block.number;
+
+  // Add hat if not already present
+  let currentHats = user.currentHatIds;
+  let found = false;
+  for (let i = 0; i < currentHats.length; i++) {
+    if (currentHats[i].equals(hatId)) {
+      found = true;
+      break;
+    }
+  }
+  if (!found) {
+    currentHats.push(hatId);
+    user.currentHatIds = currentHats;
+    if (user.membershipStatus == "Inactive") {
+      user.membershipStatus = "Active";
+      user.organization = orgId;
+    }
+    recordHatChangeLog(user, hatId, true, event);
+  }
+  user.save();
+
+  // Sync RoleWearer (only when a Role exists — system hats may not have one)
+  let roleId = orgId.toHexString() + "-" + hatId.toString();
+  let role = Role.load(roleId);
+  if (role != null && shouldCreateRoleWearer(orgId, hatId, wearer)) {
+    let rwId = roleId + "-" + wearer.toHexString();
+    let rw = RoleWearer.load(rwId);
+    if (rw == null) {
+      rw = new RoleWearer(rwId);
+      rw.role = roleId;
+      rw.user = user.id;
+      rw.wearer = wearer;
+      rw.wearerUsername = getUsernameForAddress(wearer);
+      rw.addedAt = event.block.timestamp;
+      rw.addedAtBlock = event.block.number;
+      rw.transactionHash = event.transaction.hash;
+    }
+    rw.isActive = true;
+    rw.removedAt = null;
+    rw.save();
+  }
+}
+
+/**
+ * Apply a Hats Protocol token-state burn / transfer-out for (orgId, wearer, hatId).
+ *
+ * Removes hatId from User.currentHatIds and marks the corresponding RoleWearer
+ * inactive. If the user holds no other hats afterward, they are marked Inactive
+ * and unlinked from the org (matching the prior recordUserHatChange behavior).
+ *
+ * Idempotent: removing an already-absent hat is a no-op.
+ */
+export function applyHatTransferRemove(
+  orgId: Bytes,
+  wearer: Address,
+  hatId: BigInt,
+  event: ethereum.Event
+): void {
+  if (isSystemContract(orgId, wearer)) {
+    return;
+  }
+  let userId = orgId.toHexString() + "-" + wearer.toHexString();
+  let user = User.load(userId);
+  if (user != null) {
+    let currentHats = user.currentHatIds;
+    let newHats: BigInt[] = [];
+    let removed = false;
+    for (let i = 0; i < currentHats.length; i++) {
+      if (currentHats[i].equals(hatId)) {
+        removed = true;
+      } else {
+        newHats.push(currentHats[i]);
+      }
+    }
+    if (removed) {
+      user.currentHatIds = newHats;
+      if (newHats.length == 0) {
+        user.membershipStatus = "Inactive";
+        user.organization = null;
+      }
+      recordHatChangeLog(user, hatId, false, event);
+      user.save();
+    }
+  }
+
+  let roleId = orgId.toHexString() + "-" + hatId.toString();
+  let rwId = roleId + "-" + wearer.toHexString();
+  let rw = RoleWearer.load(rwId);
+  if (rw != null && rw.isActive) {
+    rw.isActive = false;
+    rw.removedAt = event.block.timestamp;
+    rw.save();
+  }
+}
+
+/**
+ * Internal: record a UserHatChange entry without touching User.currentHatIds
+ * (caller is responsible for that). Mirrors the immutable-id rules used by
+ * recordUserHatChange so dual-callers don't collide.
+ */
+function recordHatChangeLog(
+  user: User,
+  hatId: BigInt,
+  added: boolean,
+  event: ethereum.Event
+): void {
+  let id = event.transaction.hash.concatI32(event.logIndex.toI32())
+    .concat(Bytes.fromUTF8(user.id))
+    .concat(Bytes.fromByteArray(Bytes.fromBigInt(hatId)));
+  let change = new UserHatChange(id);
+  change.user = user.id;
+  change.hatId = hatId;
+  change.added = added;
+  change.changedAt = event.block.timestamp;
+  change.changedAtBlock = event.block.number;
+  change.transactionHash = event.transaction.hash;
+  change.save();
 }
 
 /**

--- a/pop-subgraph/subgraph.yaml
+++ b/pop-subgraph/subgraph.yaml
@@ -6,11 +6,11 @@ schema:
 dataSources:
   - kind: ethereum
     name: GovernanceFactory
-    network: arbitrum-one
+    network: gnosis
     source:
       abi: GovernanceFactory
-      address: "0x24Fd3b269905AF10A6E5c67D93F0502Cd11Af875"
-      startBlock: 447059876
+      address: "0x7B023B9566b96616D54935AE8De80579c93f62aC"
+      startBlock: 45408008
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9
@@ -27,11 +27,11 @@ dataSources:
       file: ./src/governance-factory.ts
   - kind: ethereum
     name: PoaManager
-    network: arbitrum-one
+    network: gnosis
     source:
       abi: PoaManager
-      address: "0xFF585Fae4A944cD173B19158C6FC5E08980b0815"
-      startBlock: 447059849
+      address: "0x794fD39e75140ee1545B1B022E5486B7c863789b"
+      startBlock: 45407962
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9
@@ -58,11 +58,11 @@ dataSources:
       file: ./src/poa-manager.ts
   - kind: ethereum
     name: PoaManagerHub
-    network: arbitrum-one
+    network: gnosis
     source:
       abi: PoaManagerHub
-      address: "0xB72840B343654eAfb2CFf7acC4Fc6b59E6c3CC71"
-      startBlock: 447060030
+      address: "0x0000000000000000000000000000000000000000"
+      startBlock: 45407962
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9
@@ -92,11 +92,11 @@ dataSources:
       file: ./src/poa-manager-hub.ts
   - kind: ethereum
     name: PoaManagerSatellite
-    network: arbitrum-one
+    network: gnosis
     source:
       abi: PoaManagerSatellite
-      address: "0x0000000000000000000000000000000000000000"
-      startBlock: 447059849
+      address: "0x4Ad70029a9247D369a5bEA92f90840B9ee58eD06"
+      startBlock: 45408030
     mapping:
       kind: ethereum/events
       apiVersion: 0.0.9
@@ -119,10 +119,40 @@ dataSources:
         - event: PauseSet(bool)
           handler: handleSatellitePauseSet
       file: ./src/poa-manager-satellite.ts
+  - kind: ethereum
+    name: Hats
+    network: gnosis
+    source:
+      abi: Hats
+      address: "0x3bc1A0Ad72417f2d411118085256fC53CBdDd137"
+      startBlock: 45407962
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      entities:
+        - User
+        - Role
+        - RoleWearer
+        - HatLookup
+        - UserHatChange
+      abis:
+        - name: Hats
+          file: ./abis/Hats.json
+      eventHandlers:
+        - event: TransferSingle(indexed address,indexed address,indexed
+            address,uint256,uint256)
+          handler: handleHatsTransferSingle
+        - event: TransferBatch(indexed address,indexed address,indexed
+            address,uint256[],uint256[])
+          handler: handleHatsTransferBatch
+        - event: HatStatusChanged(uint256,bool)
+          handler: handleHatsStatusChanged
+      file: ./src/hats.ts
 templates:
   - kind: ethereum
     name: OrgDeployer
-    network: arbitrum-one
+    network: gnosis
     source:
       abi: OrgDeployer
     mapping:
@@ -147,7 +177,7 @@ templates:
       file: ./src/org-deployer.ts
   - kind: ethereum
     name: OrgRegistry
-    network: arbitrum-one
+    network: gnosis
     source:
       abi: OrgRegistry
     mapping:
@@ -178,7 +208,7 @@ templates:
       file: ./src/org-registry.ts
   - kind: ethereum
     name: PaymasterHub
-    network: arbitrum-one
+    network: gnosis
     source:
       abi: PaymasterHub
     mapping:
@@ -252,7 +282,7 @@ templates:
       file: ./src/paymaster-hub.ts
   - kind: ethereum
     name: UniversalAccountRegistry
-    network: arbitrum-one
+    network: gnosis
     source:
       abi: UniversalAccountRegistry
     mapping:
@@ -290,7 +320,7 @@ templates:
       file: ./src/universal-account-registry.ts
   - kind: ethereum
     name: TaskManager
-    network: arbitrum-one
+    network: gnosis
     source:
       abi: TaskManager
     mapping:
@@ -347,7 +377,7 @@ templates:
       file: ./src/task-manager.ts
   - kind: ethereum
     name: HybridVoting
-    network: arbitrum-one
+    network: gnosis
     source:
       abi: HybridVoting
     mapping:
@@ -399,7 +429,7 @@ templates:
       file: ./src/hybrid-voting.ts
   - kind: ethereum
     name: DirectDemocracyVoting
-    network: arbitrum-one
+    network: gnosis
     source:
       abi: DirectDemocracyVoting
     mapping:
@@ -451,7 +481,7 @@ templates:
       file: ./src/direct-democracy-voting.ts
   - kind: ethereum
     name: EligibilityModule
-    network: arbitrum-one
+    network: gnosis
     source:
       abi: EligibilityModule
     mapping:
@@ -520,7 +550,7 @@ templates:
       file: ./src/eligibility-module.ts
   - kind: ethereum
     name: ParticipationToken
-    network: arbitrum-one
+    network: gnosis
     source:
       abi: ParticipationToken
     mapping:
@@ -562,7 +592,7 @@ templates:
       file: ./src/participation-token.ts
   - kind: ethereum
     name: QuickJoin
-    network: arbitrum-one
+    network: gnosis
     source:
       abi: QuickJoin
     mapping:
@@ -610,7 +640,7 @@ templates:
       file: ./src/quick-join.ts
   - kind: ethereum
     name: EducationHub
-    network: arbitrum-one
+    network: gnosis
     source:
       abi: EducationHub
     mapping:
@@ -661,7 +691,7 @@ templates:
       file: ./src/education-hub.ts
   - kind: ethereum
     name: PaymentManager
-    network: arbitrum-one
+    network: gnosis
     source:
       abi: PaymentManager
     mapping:
@@ -700,7 +730,7 @@ templates:
       file: ./src/payment-manager.ts
   - kind: ethereum
     name: Executor
-    network: arbitrum-one
+    network: gnosis
     source:
       abi: Executor
     mapping:
@@ -750,7 +780,7 @@ templates:
       file: ./src/executor.ts
   - kind: ethereum
     name: ToggleModule
-    network: arbitrum-one
+    network: gnosis
     source:
       abi: ToggleModule
     mapping:
@@ -776,7 +806,7 @@ templates:
       file: ./src/toggle-module.ts
   - kind: ethereum
     name: PasskeyAccountFactory
-    network: arbitrum-one
+    network: gnosis
     source:
       abi: PasskeyAccountFactory
     mapping:
@@ -801,7 +831,7 @@ templates:
       file: ./src/passkey-account-factory.ts
   - kind: ethereum
     name: PasskeyAccount
-    network: arbitrum-one
+    network: gnosis
     source:
       abi: PasskeyAccount
     mapping:
@@ -842,7 +872,7 @@ templates:
       file: ./src/passkey-account.ts
   - kind: ethereum
     name: SwitchableBeacon
-    network: arbitrum-one
+    network: gnosis
     source:
       abi: SwitchableBeacon
     mapping:
@@ -870,7 +900,7 @@ templates:
       file: ./src/switchable-beacon.ts
   - kind: file/ipfs
     name: OrgMetadata
-    network: arbitrum-one
+    network: gnosis
     mapping:
       apiVersion: 0.0.9
       language: wasm/assemblyscript
@@ -884,7 +914,7 @@ templates:
           file: ./abis/OrgRegistry.json
   - kind: file/ipfs
     name: HatMetadata
-    network: arbitrum-one
+    network: gnosis
     mapping:
       apiVersion: 0.0.9
       language: wasm/assemblyscript
@@ -897,7 +927,7 @@ templates:
           file: ./abis/EligibilityModule.json
   - kind: file/ipfs
     name: TaskMetadata
-    network: arbitrum-one
+    network: gnosis
     mapping:
       apiVersion: 0.0.9
       language: wasm/assemblyscript
@@ -910,7 +940,7 @@ templates:
           file: ./abis/TaskManager.json
   - kind: file/ipfs
     name: ProjectMetadata
-    network: arbitrum-one
+    network: gnosis
     mapping:
       apiVersion: 0.0.9
       language: wasm/assemblyscript
@@ -923,7 +953,7 @@ templates:
           file: ./abis/TaskManager.json
   - kind: file/ipfs
     name: ProposalMetadata
-    network: arbitrum-one
+    network: gnosis
     mapping:
       apiVersion: 0.0.9
       language: wasm/assemblyscript
@@ -936,7 +966,7 @@ templates:
           file: ./abis/HybridVoting.json
   - kind: file/ipfs
     name: EducationModuleMetadata
-    network: arbitrum-one
+    network: gnosis
     mapping:
       apiVersion: 0.0.9
       language: wasm/assemblyscript
@@ -949,7 +979,7 @@ templates:
           file: ./abis/EducationHub.json
   - kind: file/ipfs
     name: TokenRequestMetadata
-    network: arbitrum-one
+    network: gnosis
     mapping:
       apiVersion: 0.0.9
       language: wasm/assemblyscript
@@ -962,7 +992,7 @@ templates:
           file: ./abis/ParticipationToken.json
   - kind: file/ipfs
     name: TaskApplicationMetadata
-    network: arbitrum-one
+    network: gnosis
     mapping:
       apiVersion: 0.0.9
       language: wasm/assemblyscript
@@ -975,7 +1005,7 @@ templates:
           file: ./abis/TaskManager.json
   - kind: file/ipfs
     name: AccountMetadata
-    network: arbitrum-one
+    network: gnosis
     mapping:
       apiVersion: 0.0.9
       language: wasm/assemblyscript

--- a/pop-subgraph/tests/eligibility-module.test.ts
+++ b/pop-subgraph/tests/eligibility-module.test.ts
@@ -218,6 +218,7 @@ function createHatEntity(hatId: BigInt): void {
   hat.defaultEligible = true;
   hat.defaultStanding = true;
   hat.mintedCount = BigInt.fromI32(0);
+  hat.active = true;
   hat.createdAt = BigInt.fromI32(1000);
   hat.createdAtBlock = BigInt.fromI32(100);
   hat.transactionHash = Bytes.fromHexString("0xabcd");

--- a/pop-subgraph/tests/hat-metadata.test.ts
+++ b/pop-subgraph/tests/hat-metadata.test.ts
@@ -68,6 +68,7 @@ function createMockHat(hatEntityId: string): void {
   hat.defaultEligible = true;
   hat.defaultStanding = true;
   hat.mintedCount = BigInt.fromI32(0);
+  hat.active = true;
   hat.createdAt = BigInt.fromI32(1000);
   hat.createdAtBlock = BigInt.fromI32(100);
   hat.transactionHash = Bytes.fromHexString("0xabcd");


### PR DESCRIPTION
Closes #166.

## Problem

`User.currentHatIds` and `RoleWearer.isActive` were driven from `EligibilityModule.WearerEligibilityUpdated` / `BulkWearerEligibilityUpdated`. That fails whenever an eligibility revoke does NOT actually burn the Hats Protocol token. With `combineWithHierarchy=true` vouching, `Hats.getWearerStatus` ORs hierarchy with vouch-based eligibility — so a wearer can be flagged `eligible=false` by the module but still pass `isWearerOfHat` on-chain. The subgraph would silently drop them.

KUBI's Executive on Gnosis was missing **caleb** and **wcalhoun04** in the frontend even though `Hats.isWearerOfHat` returned true for both.

## Fix

The Hats Protocol ERC-1155 contract is the source of truth for token state. Every mint, burn, and `transferHat` emits a `TransferSingle`. This PR routes those into `User.currentHatIds` / `RoleWearer.isActive` and removes the eligibility-driven writes.

### Files

- `abis/Hats.json` — minimal ABI (TransferSingle, TransferBatch, HatStatusChanged).
- `networks.json` — `Hats` source per chain, anchored at the canonical CREATE2 address `0x3bc1A0Ad72417f2d411118085256fC53CBdDd137` with each chain's PoaManager startBlock.
- `subgraph.yaml` — new datasource; per-network address injected by `graph build:gnosis` / `graph build:arbitrum-one`.
- `schema.graphql` — adds `HatLookup` global index (`hatId → org/role/hat`) and `Hat.active` (HatStatusChanged tracking; tokens aren't burned when a hat toggles off).
- `src/hats.ts` — TransferSingle / TransferBatch / HatStatusChanged handlers. Routes through `HatLookup` so hats outside our orgs are skipped.
- `src/utils.ts` — `applyHatTransferAdd` / `applyHatTransferRemove` (and `getOrCreateRole` now populates `HatLookup`). Creates a `User` entity on the fly with `joinMethod="HatTransfer"` when governance grants a hat to a wallet that didn't join via QuickJoin.
- `src/eligibility-module.ts` — removes the `recordUserHatChange` writes from `handleWearerEligibilityUpdated` / `handleBulkWearerEligibilityUpdated`. The eligibility view itself stays on the `WearerEligibility` entity for consumers that need it.

### Edge cases

| Case | Behavior |
|---|---|
| mint (`from=0`) | add hat, upsert RoleWearer.isActive=true |
| burn (`to=0`) | remove hat, RoleWearer.isActive=false |
| `transferHat` (both nonzero) | decomposed: remove(from) + add(to) |
| TransferBatch | per-pair iteration |
| Hat outside our orgs | `HatLookup.load` miss → skip |
| Direct grant to non-joined wallet | `User` created with `joinMethod='HatTransfer'` |
| Hat toggled off (`HatStatusChanged(false)`) | `Hat.active=false`; balances unchanged. Consumers AND `currentHatIds` with `Hat.active` for full `isWearerOfHat` semantics |
| isSystemContract (Executor, EligibilityModule) | skipped |
| value=0 TransferSingle (defensive) | skipped |

### Backfill

Subgraph re-indexes from each chain's PoaManager startBlock, so historical TransferSingles fire chronologically and entities converge to the correct token state. Any prior eligibility-driven writes that mismatched the token state are overwritten.

### Verification

- [x] `yarn codegen` clean
- [x] `yarn build:gnosis` clean
- [x] `yarn build:arbitrum-one` clean
- [ ] After redeploy + reindex on Gnosis, `organization(...).users { currentHatIds }` for KUBI returns all 10 Executive wearers (caleb + wcalhoun04 included).
- [ ] Frontend ElectionConfigurator's role cards under-report no longer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)