### PR TITLE
fix: stop driving RoleWearer.isActive off eligibility events

### DIFF
--- a/pop-subgraph/src/eligibility-module.ts
+++ b/pop-subgraph/src/eligibility-module.ts
@@ -224,19 +224,14 @@ export function handleWearerEligibilityUpdated(
 
   wearerEligibility.save();
 
-  // Sync RoleWearer.isActive with eligibility status
+  // Link wearerEligibility to RoleWearer for the eligibility-rules view.
+  // NOTE: RoleWearer.isActive is no longer set here — it now reflects ERC-1155
+  // token state via Hats.TransferSingle (see issue #166). Eligibility-only
+  // revokes don't burn tokens (vouching with combineWithHierarchy=true), so
+  // flipping isActive off them was wrong. Consumers wanting eligibility-aware
+  // semantics should AND RoleWearer.isActive with WearerEligibility.{eligible,
+  // standing} via the linked WearerEligibility.
   if (eligibilityModule) {
-    // A wearer is active if they are both eligible AND in good standing
-    let isActive = event.params.eligible && event.params.standing;
-    updateRoleWearerStatus(
-      eligibilityModule.organization,
-      hatId,
-      wearer,
-      isActive,
-      event
-    );
-
-    // Link wearerEligibility to RoleWearer
     linkWearerEligibilityToRoleWearer(
       eligibilityModule.organization,
       hatId,
@@ -317,19 +312,9 @@ export function handleBulkWearerEligibilityUpdated(
 
     wearerEligibility.save();
 
-    // Sync RoleWearer.isActive with eligibility status
+    // Same fix as the single-wearer path above: only the eligibility view
+    // is updated, the token-state view (RoleWearer.isActive) is left alone.
     if (eligibilityModule) {
-      // A wearer is active if they are both eligible AND in good standing
-      let isActive = eligible && standing;
-      updateRoleWearerStatus(
-        eligibilityModule.organization,
-        hatId,
-        wearer,
-        isActive,
-        event
-      );
-
-      // Link wearerEligibility to RoleWearer
       linkWearerEligibilityToRoleWearer(
         eligibilityModule.organization,
         hatId,


### PR DESCRIPTION
Follow-up to #169.

## Live verification of #169 found the bug

After #169 merged + deployed to The Graph Studio (poa-gnosis-v-1), I queried KUBI's Executive role:

```
{
  role(id: "0xc0f2765d...c2102e-29089782865237956770482606498400312925615312744021346470950225330569216") {
    wearers { wearer wearerUsername isActive }
  }
}
```

Result: 8 wearers `isActive: true`, **caleb and wcalhoun04 still `isActive: false`**. They wear the hat on-chain (verified via `Hats.isWearerOfHat`).

## Root cause

#169 removed `recordUserHatChange` calls from `eligibility-module.ts` (which drove `User.currentHatIds`) but left `updateRoleWearerStatus` in place — which *also* drove `RoleWearer.isActive` off the same eligibility events. So:
- `User.currentHatIds` correctly contains the hatId for caleb/wcalhoun04 (TransferSingle was the source).
- `RoleWearer.isActive` is wrong because it was flipped off when their eligibility was revoked, even though the token was never burned.

## Fix

Strip `updateRoleWearerStatus` from both `handleWearerEligibilityUpdated` and `handleBulkWearerEligibilityUpdated`. `linkWearerEligibilityToRoleWearer` stays — the eligibility view is still attached to the RoleWearer for consumers who want it. `Hats.TransferSingle` is now the only legitimate signal for `RoleWearer.isActive` transitions.

The doc comment on `RoleWearer.isActive` from #169 already documents the new contract: token-state-only, AND with `Hat.active` and the linked `WearerEligibility` for full `isWearerOfHat` semantics.

## Tests

241/241 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)