### PR TITLE
chore(abi): sync TaskManager ABI with createTasksBatch upgrade

### DIFF
--- a/pop-subgraph/abis/TaskManager.json
+++ b/pop-subgraph/abis/TaskManager.json
@@ -400,6 +400,62 @@
   },
   {
     "type": "function",
+    "name": "createTasksBatch",
+    "inputs": [
+      {
+        "name": "pid",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "tasks",
+        "type": "tuple[]",
+        "internalType": "struct TaskManager.CreateTaskInput[]",
+        "components": [
+          {
+            "name": "payout",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "title",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "metadataHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "bountyToken",
+            "type": "address",
+            "internalType": "address"
+          },
+          {
+            "name": "bountyPayout",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "requiresApplication",
+            "type": "bool",
+            "internalType": "bool"
+          }
+        ]
+      }
+    ],
+    "outputs": [
+      {
+        "name": "taskIds",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "deleteProject",
     "inputs": [
       {
@@ -1100,6 +1156,11 @@
   {
     "type": "error",
     "name": "CapBelowCommitted",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyBatch",
     "inputs": []
   },
   {


### PR DESCRIPTION
## Summary
- Syncs `pop-subgraph/abis/TaskManager.json` with the `createTasksBatch + v2 upgrade` change in poa-contracts (commit 90f199d2). Adds the new `createTasksBatch(bytes32, CreateTaskInput[])` function and `EmptyBatch` error.
- No event signature changes, so no schema, mapping, or `subgraph.yaml` updates are needed — drop-in safe for the existing subgraph. TaskManager addresses are dynamically discovered, so `networks.json` is also untouched.

## Test plan
- [x] `yarn codegen` clean
- [x] `yarn build` clean
- [x] `yarn test` — 241/241 pass
- [x] `subgraph-lint` — 0 errors (only the 9 pre-existing `undeclared-eth-call` warnings on `poa-manager.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)