### PR TITLE
feat(task-manager): index v4 events — folders, organizer hats, global TaskPerm

### DIFF
--- a/pop-subgraph/abis/TaskManager.json
+++ b/pop-subgraph/abis/TaskManager.json
@@ -685,6 +685,31 @@
   },
   {
     "type": "event",
+    "name": "FoldersUpdated",
+    "inputs": [
+      {
+        "name": "newRoot",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "oldRoot",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "sender",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "HatSet",
     "inputs": [
       {
@@ -736,6 +761,25 @@
         "type": "uint64",
         "indexed": false,
         "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "OrganizerHatAllowed",
+    "inputs": [
+      {
+        "name": "hatId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "allowed",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
       }
     ],
     "anonymous": false
@@ -844,6 +888,25 @@
         "indexed": true,
         "internalType": "bytes32"
       },
+      {
+        "name": "hatId",
+        "type": "uint256",
+        "indexed": true,
+        "internalType": "uint256"
+      },
+      {
+        "name": "mask",
+        "type": "uint8",
+        "indexed": false,
+        "internalType": "uint8"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RolePermSet",
+    "inputs": [
       {
         "name": "hatId",
         "type": "uint256",

--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -32,6 +32,13 @@ type Organization @entity(immutable: false) {
   metadataAdminHatId: BigInt
   registeredContracts: [RegisteredContract!]! @derivedFrom(field: "organization")
   roles: [Role!]! @derivedFrom(field: "organization")
+  # Project folders (TaskManager v4) — IPFS root for the org's folder tree.
+  # bytes32 sha256 digest; frontend prepends 0x1220 and base58-encodes to a CIDv0.
+  # Null until the first setFolders() call.
+  foldersRoot: Bytes
+  foldersUpdatedAt: BigInt
+  foldersUpdatedBy: Bytes # _msgSender() from FoldersUpdated (smart-wallet-aware)
+  folderRootChanges: [FolderRootChange!]! @derivedFrom(field: "organization")
 }
 
 # ========================================
@@ -98,6 +105,10 @@ type TaskManager @entity(immutable: false) {
   organization: Organization! # Organization this TaskManager belongs to
   projects: [Project!]! @derivedFrom(field: "taskManager")
   creatorHatIds: [BigInt!]! # Hat IDs that can create projects (derived from org config)
+  # Hat IDs authorized to call setFolders (TaskManager v4).
+  # Managed via setConfig(ORGANIZER_HAT_ALLOWED, ...) which emits OrganizerHatAllowed.
+  organizerHatIds: [BigInt!]!
+  globalRolePermissions: [GlobalRolePermission!]! @derivedFrom(field: "taskManager")
   createdAt: BigInt!
   createdAtBlock: BigInt!
   transactionHash: Bytes!
@@ -217,6 +228,49 @@ type BountyCapChange @entity(immutable: true) {
   newCap: BigInt!
   changedAt: BigInt!
   changedAtBlock: BigInt!
+  transactionHash: Bytes!
+}
+
+# ========================================
+# TaskManager v4 — Folders + Global Role Permissions
+# ========================================
+
+"""
+Immutable record of a folders-root revision emitted by TaskManager.setFolders().
+Use these to render a revision log; current root is on Organization.foldersRoot.
+"""
+type FolderRootChange @entity(immutable: true) {
+  id: Bytes! # txHash-logIndex
+  organization: Organization!
+  newRoot: Bytes! # bytes32 sha256 digest of the new IPFS root
+  oldRoot: Bytes! # previous root (zero bytes if first emission)
+  sender: Bytes! # _msgSender() from event — smart-wallet-aware "who edited"
+  senderUser: User # nullable — populated only if sender is a known org member
+  senderUsername: String
+  changedAt: BigInt!
+  changedAtBlock: BigInt!
+  transactionHash: Bytes!
+}
+
+"""
+Global TaskPerm grants set via setConfig(ROLE_PERM, ...) on TaskManager.
+Distinct from per-project grants (see ProjectRolePermission); a hat may hold
+TaskPerm.BUDGET (or any other bit) globally without per-project entries.
+mask=0 means the hat was revoked.
+"""
+type GlobalRolePermission @entity(immutable: false) {
+  id: String! # taskManager-hatId (composite key for cross-org isolation)
+  taskManager: TaskManager!
+  hatId: BigInt!
+  mask: Int! # uint8 (CREATE=1, CLAIM=2, REVIEW=4, ASSIGN=8, SELF_REVIEW=16, BUDGET=32)
+  canCreate: Boolean! # mask & 1
+  canClaim: Boolean! # mask & 2
+  canReview: Boolean! # mask & 4
+  canAssign: Boolean! # mask & 8
+  canSelfReview: Boolean! # mask & 16
+  canBudget: Boolean! # mask & 32 — TaskPerm.BUDGET (resize project caps)
+  setAt: BigInt!
+  setAtBlock: BigInt!
   transactionHash: Bytes!
 }
 

--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -188,11 +188,13 @@ type ProjectRolePermission @entity(immutable: false) {
   id: String! # taskManager-projectId-hatId (composite key)
   project: Project!
   hatId: BigInt!
-  mask: Int! # Permission bitmask (uint8: create=1, claim=2, review=4, assign=8)
+  mask: Int! # Permission bitmask (uint8: create=1, claim=2, review=4, assign=8, selfReview=16, budget=32)
   canCreate: Boolean! # mask & 1
   canClaim: Boolean! # mask & 2
   canReview: Boolean! # mask & 4
   canAssign: Boolean! # mask & 8
+  canSelfReview: Boolean! # mask & 16 — TaskPerm.SELF_REVIEW (review own submissions)
+  canBudget: Boolean! # mask & 32 — TaskPerm.BUDGET (per-project override of global BUDGET grant)
   setAt: BigInt!
   setAtBlock: BigInt!
   transactionHash: Bytes!

--- a/pop-subgraph/src/org-deployer.ts
+++ b/pop-subgraph/src/org-deployer.ts
@@ -60,6 +60,7 @@ export function handleOrgDeployed(event: OrgDeployed): void {
     creatorHatIds.push(roleHatIds[i]);
   }
   taskManager.creatorHatIds = creatorHatIds;
+  taskManager.organizerHatIds = []; // populated by OrganizerHatAllowed events (TaskManager v4)
 
   // Create HybridVotingContract entity
   let hybridVoting = new HybridVotingContract(event.params.hybridVoting);

--- a/pop-subgraph/src/task-manager.ts
+++ b/pop-subgraph/src/task-manager.ts
@@ -580,7 +580,10 @@ export function handleProjectManagerUpdated(event: ProjectManagerUpdated): void 
 /**
  * Handles the ProjectRolePermSet event from a TaskManager contract.
  * Creates or updates a ProjectRolePermission entity to track hat-based permissions.
- * Permission bitmask: CREATE=1, CLAIM=2, REVIEW=4, ASSIGN=8
+ * Permission bitmask: CREATE=1, CLAIM=2, REVIEW=4, ASSIGN=8, SELF_REVIEW=16, BUDGET=32.
+ * SELF_REVIEW and BUDGET were added in TaskManager v4 — the contract permits both
+ * bits in per-project masks, so decoding them here keeps `where: { canBudget: true }`
+ * queries working without forcing frontends to bit-AND raw masks.
  *
  * Note: This event may be emitted BEFORE ProjectCreated in the same transaction.
  */
@@ -606,11 +609,12 @@ export function handleProjectRolePermSet(event: ProjectRolePermSet): void {
   }
 
   perm.mask = mask;
-  // Decode permission bits: CREATE=1, CLAIM=2, REVIEW=4, ASSIGN=8
   perm.canCreate = (mask & 1) != 0;
   perm.canClaim = (mask & 2) != 0;
   perm.canReview = (mask & 4) != 0;
   perm.canAssign = (mask & 8) != 0;
+  perm.canSelfReview = (mask & 16) != 0;
+  perm.canBudget = (mask & 32) != 0;
   perm.setAt = event.block.timestamp;
   perm.setAtBlock = event.block.number;
   perm.transactionHash = event.transaction.hash;

--- a/pop-subgraph/src/task-manager.ts
+++ b/pop-subgraph/src/task-manager.ts
@@ -16,18 +16,24 @@ import {
   TaskUpdated,
   TaskApplicationSubmitted,
   TaskApplicationApproved,
-  TaskRejected
+  TaskRejected,
+  FoldersUpdated,
+  OrganizerHatAllowed,
+  RolePermSet
 } from "../generated/templates/TaskManager/TaskManager";
 import {
   Project,
   Task,
   TaskApplication,
   TaskManager,
+  Organization,
   ProjectManager,
   ProjectRolePermission,
+  GlobalRolePermission,
   ProjectBountyCap,
   ProjectCapChange,
   BountyCapChange,
+  FolderRootChange,
   TaskMetadata,
   TaskApplicationMetadata,
   ProjectMetadata,
@@ -720,4 +726,117 @@ export function handleTaskRejected(event: TaskRejected): void {
   }
 
   rejection.save();
+}
+
+/**
+ * Handles the FoldersUpdated event from a TaskManager contract (v4).
+ * Stores the new IPFS root on the Organization and appends a FolderRootChange
+ * record so frontends can render a revision log. The subgraph does not resolve
+ * the folder-tree JSON itself — the frontend fetches IPFS at the root.
+ */
+export function handleFoldersUpdated(event: FoldersUpdated): void {
+  let taskManager = TaskManager.load(event.address);
+  if (!taskManager) return;
+
+  let organization = Organization.load(taskManager.organization);
+  if (!organization) return;
+
+  organization.foldersRoot = event.params.newRoot;
+  organization.foldersUpdatedAt = event.block.timestamp;
+  organization.foldersUpdatedBy = event.params.sender;
+  organization.save();
+
+  let changeId = event.transaction.hash.concatI32(event.logIndex.toI32());
+  let change = new FolderRootChange(changeId);
+  change.organization = organization.id;
+  change.newRoot = event.params.newRoot;
+  change.oldRoot = event.params.oldRoot;
+  change.sender = event.params.sender;
+  change.senderUsername = getUsernameForAddress(event.params.sender);
+
+  let user = loadExistingUser(
+    organization.id,
+    event.params.sender,
+    event.block.timestamp,
+    event.block.number
+  );
+  if (user) {
+    change.senderUser = user.id;
+  }
+
+  change.changedAt = event.block.timestamp;
+  change.changedAtBlock = event.block.number;
+  change.transactionHash = event.transaction.hash;
+  change.save();
+}
+
+/**
+ * Handles the OrganizerHatAllowed event from a TaskManager contract (v4).
+ * Mutates the denormalized organizerHatIds array on the TaskManager entity.
+ * Mirrors the contract's HatManager.setHatInArray semantics: add if allowed
+ * and not already present; remove if revoked and present. No-op otherwise.
+ */
+export function handleOrganizerHatAllowed(event: OrganizerHatAllowed): void {
+  let taskManager = TaskManager.load(event.address);
+  if (!taskManager) return;
+
+  let hatId = event.params.hatId;
+  let allowed = event.params.allowed;
+
+  // Copy-mutate-reassign — AssemblyScript array fields don't mutate in place.
+  let current = taskManager.organizerHatIds;
+  let next: BigInt[] = [];
+  let found = false;
+  for (let i = 0; i < current.length; i++) {
+    if (current[i].equals(hatId)) {
+      found = true;
+      if (allowed) {
+        next.push(current[i]); // keep
+      }
+      // if !allowed, drop
+    } else {
+      next.push(current[i]);
+    }
+  }
+  if (allowed && !found) {
+    next.push(hatId);
+  }
+
+  taskManager.organizerHatIds = next;
+  taskManager.save();
+}
+
+/**
+ * Handles the RolePermSet event from a TaskManager contract (v4).
+ * Upserts a GlobalRolePermission entity keyed by (taskManager, hatId).
+ * Writes the mask verbatim — mask=0 (revoke) is intentionally preserved so
+ * frontends can distinguish "never granted" (no entity) from "explicitly revoked"
+ * (entity with mask=0). Decodes all 6 TaskPerm bits for query convenience.
+ */
+export function handleRolePermSet(event: RolePermSet): void {
+  let taskManager = TaskManager.load(event.address);
+  if (!taskManager) return;
+
+  let hatId = event.params.hatId;
+  let mask = event.params.mask;
+
+  let id = event.address.toHexString() + "-" + hatId.toString();
+  let perm = GlobalRolePermission.load(id);
+  if (perm == null) {
+    perm = new GlobalRolePermission(id);
+    perm.taskManager = event.address;
+    perm.hatId = hatId;
+  }
+
+  perm.mask = mask;
+  perm.canCreate = (mask & 1) != 0;
+  perm.canClaim = (mask & 2) != 0;
+  perm.canReview = (mask & 4) != 0;
+  perm.canAssign = (mask & 8) != 0;
+  perm.canSelfReview = (mask & 16) != 0;
+  perm.canBudget = (mask & 32) != 0;
+  perm.setAt = event.block.timestamp;
+  perm.setAtBlock = event.block.number;
+  perm.transactionHash = event.transaction.hash;
+  perm.save();
 }

--- a/pop-subgraph/subgraph.yaml
+++ b/pop-subgraph/subgraph.yaml
@@ -337,6 +337,10 @@ templates:
         - ProjectBountyCap
         - ProjectCapChange
         - BountyCapChange
+        - FolderRootChange
+        - GlobalRolePermission
+        - Organization
+        - TaskManager
       abis:
         - name: TaskManager
           file: ./abis/TaskManager.json
@@ -353,6 +357,12 @@ templates:
           handler: handleProjectRolePermSet
         - event: BountyCapSet(indexed bytes32,indexed address,uint256,uint256)
           handler: handleBountyCapSet
+        - event: FoldersUpdated(indexed bytes32,indexed bytes32,indexed address)
+          handler: handleFoldersUpdated
+        - event: OrganizerHatAllowed(indexed uint256,bool)
+          handler: handleOrganizerHatAllowed
+        - event: RolePermSet(indexed uint256,uint8)
+          handler: handleRolePermSet
         - event: TaskCreated(indexed uint256,indexed
             bytes32,uint256,address,uint256,bool,bytes,bytes32)
           handler: handleTaskCreated

--- a/pop-subgraph/tests/eligibility-module.test.ts
+++ b/pop-subgraph/tests/eligibility-module.test.ts
@@ -104,6 +104,7 @@ function setupEligibilityModuleEntities(): void {
   let taskManager = new TaskManager(taskManagerAddress);
   taskManager.organization = orgId;
   taskManager.creatorHatIds = [BigInt.fromI32(1002)];
+  taskManager.organizerHatIds = []; // populated by OrganizerHatAllowed events (v4)
   taskManager.createdAt = BigInt.fromI32(1000);
   taskManager.createdAtBlock = BigInt.fromI32(100);
   taskManager.transactionHash = Bytes.fromHexString("0xabcd");

--- a/pop-subgraph/tests/executor.test.ts
+++ b/pop-subgraph/tests/executor.test.ts
@@ -88,6 +88,7 @@ function setupExecutorEntities(): void {
   let taskManager = new TaskManager(taskManagerAddress);
   taskManager.organization = orgId;
   taskManager.creatorHatIds = [BigInt.fromI32(1002)]; // Non-member roles that can create projects
+  taskManager.organizerHatIds = []; // populated by OrganizerHatAllowed events (v4)
   taskManager.createdAt = BigInt.fromI32(1000);
   taskManager.createdAtBlock = BigInt.fromI32(100);
   taskManager.transactionHash = Bytes.fromHexString("0xabcd");

--- a/pop-subgraph/tests/hybrid-voting.test.ts
+++ b/pop-subgraph/tests/hybrid-voting.test.ts
@@ -76,6 +76,7 @@ function setupHybridVotingContract(contractAddress: Address): void {
   let taskManager = new TaskManager(taskManagerAddress);
   taskManager.organization = orgId;
   taskManager.creatorHatIds = [BigInt.fromI32(1002)]; // Non-member roles that can create projects
+  taskManager.organizerHatIds = []; // populated by OrganizerHatAllowed events (v4)
   taskManager.createdAt = BigInt.fromI32(1000);
   taskManager.createdAtBlock = BigInt.fromI32(100);
   taskManager.transactionHash = Bytes.fromHexString("0xabcd");

--- a/pop-subgraph/tests/org-deployer.test.ts
+++ b/pop-subgraph/tests/org-deployer.test.ts
@@ -303,6 +303,13 @@ describe("OrgDeployer", () => {
       "creatorHatIds",
       "[1002, 1003]"
     );
+    // organizerHatIds (v4) is initialized empty; populated later by OrganizerHatAllowed events.
+    assert.fieldEquals(
+      "TaskManager",
+      "0x0000000000000000000000000000000000000006",
+      "organizerHatIds",
+      "[]"
+    );
   });
 
   test("TaskManager.creatorHatIds empty when only member role in roleHatIds", () => {

--- a/pop-subgraph/tests/task-manager-utils.ts
+++ b/pop-subgraph/tests/task-manager-utils.ts
@@ -11,7 +11,10 @@ import {
   TaskAssigned,
   TaskSubmitted,
   TaskCompleted,
-  TaskRejected
+  TaskRejected,
+  FoldersUpdated,
+  OrganizerHatAllowed,
+  RolePermSet
 } from "../generated/templates/TaskManager/TaskManager";
 
 export function createProjectCreatedEvent(
@@ -239,6 +242,61 @@ export function createBountyCapSetEvent(
   );
   event.parameters.push(
     new ethereum.EventParam("newCap", ethereum.Value.fromUnsignedBigInt(newCap))
+  );
+
+  return event;
+}
+
+export function createFoldersUpdatedEvent(
+  newRoot: Bytes,
+  oldRoot: Bytes,
+  sender: Address
+): FoldersUpdated {
+  let event = changetype<FoldersUpdated>(newMockEvent());
+
+  event.parameters = new Array();
+  event.parameters.push(
+    new ethereum.EventParam("newRoot", ethereum.Value.fromFixedBytes(newRoot))
+  );
+  event.parameters.push(
+    new ethereum.EventParam("oldRoot", ethereum.Value.fromFixedBytes(oldRoot))
+  );
+  event.parameters.push(
+    new ethereum.EventParam("sender", ethereum.Value.fromAddress(sender))
+  );
+
+  return event;
+}
+
+export function createOrganizerHatAllowedEvent(
+  hatId: BigInt,
+  allowed: boolean
+): OrganizerHatAllowed {
+  let event = changetype<OrganizerHatAllowed>(newMockEvent());
+
+  event.parameters = new Array();
+  event.parameters.push(
+    new ethereum.EventParam("hatId", ethereum.Value.fromUnsignedBigInt(hatId))
+  );
+  event.parameters.push(
+    new ethereum.EventParam("allowed", ethereum.Value.fromBoolean(allowed))
+  );
+
+  return event;
+}
+
+export function createRolePermSetEvent(
+  hatId: BigInt,
+  mask: i32
+): RolePermSet {
+  let event = changetype<RolePermSet>(newMockEvent());
+
+  event.parameters = new Array();
+  event.parameters.push(
+    new ethereum.EventParam("hatId", ethereum.Value.fromUnsignedBigInt(hatId))
+  );
+  event.parameters.push(
+    new ethereum.EventParam("mask", ethereum.Value.fromI32(mask))
   );
 
   return event;

--- a/pop-subgraph/tests/task-manager.test.ts
+++ b/pop-subgraph/tests/task-manager.test.ts
@@ -17,7 +17,10 @@ import {
   handleProjectManagerUpdated,
   handleProjectRolePermSet,
   handleBountyCapSet,
-  handleTaskRejected
+  handleTaskRejected,
+  handleFoldersUpdated,
+  handleOrganizerHatAllowed,
+  handleRolePermSet
 } from "../src/task-manager";
 import {
   createProjectCreatedEvent,
@@ -29,7 +32,10 @@ import {
   createProjectManagerUpdatedEvent,
   createProjectRolePermSetEvent,
   createBountyCapSetEvent,
-  createTaskRejectedEvent
+  createTaskRejectedEvent,
+  createFoldersUpdatedEvent,
+  createOrganizerHatAllowedEvent,
+  createRolePermSetEvent
 } from "./task-manager-utils";
 import { Organization, TaskManager, HybridVotingContract, DirectDemocracyVotingContract, EligibilityModuleContract, ParticipationTokenContract, QuickJoinContract, EducationHubContract, PaymentManagerContract, ExecutorContract, ToggleModuleContract } from "../generated/schema";
 
@@ -74,6 +80,7 @@ function setupTaskManagerEntities(): void {
   let taskManager = new TaskManager(taskManagerAddress);
   taskManager.organization = orgId;
   taskManager.creatorHatIds = [BigInt.fromI32(1002)]; // Non-member roles that can create projects
+  taskManager.organizerHatIds = []; // populated by OrganizerHatAllowed events (v4)
   taskManager.createdAt = BigInt.fromI32(1000);
   taskManager.createdAtBlock = BigInt.fromI32(100);
   taskManager.transactionHash = Bytes.fromHexString("0xabcd");
@@ -831,6 +838,7 @@ describe("TaskManager", () => {
     let taskManager1 = new TaskManager(taskManager1Address);
     taskManager1.organization = orgId1;
     taskManager1.creatorHatIds = [BigInt.fromI32(1001)];
+    taskManager1.organizerHatIds = [];
     taskManager1.createdAt = BigInt.fromI32(1000);
     taskManager1.createdAtBlock = BigInt.fromI32(100);
     taskManager1.transactionHash = Bytes.fromHexString("0xabcd");
@@ -853,6 +861,7 @@ describe("TaskManager", () => {
     let taskManager2 = new TaskManager(taskManager2Address);
     taskManager2.organization = orgId2;
     taskManager2.creatorHatIds = [BigInt.fromI32(2001)];
+    taskManager2.organizerHatIds = [];
     taskManager2.createdAt = BigInt.fromI32(2000);
     taskManager2.createdAtBlock = BigInt.fromI32(200);
     taskManager2.transactionHash = Bytes.fromHexString("0xdcba");
@@ -918,6 +927,7 @@ describe("TaskManager", () => {
     let taskManager1 = new TaskManager(taskManager1Address);
     taskManager1.organization = orgId1;
     taskManager1.creatorHatIds = [BigInt.fromI32(1001)];
+    taskManager1.organizerHatIds = [];
     taskManager1.createdAt = BigInt.fromI32(1000);
     taskManager1.createdAtBlock = BigInt.fromI32(100);
     taskManager1.transactionHash = Bytes.fromHexString("0xabcd");
@@ -939,6 +949,7 @@ describe("TaskManager", () => {
     let taskManager2 = new TaskManager(taskManager2Address);
     taskManager2.organization = orgId2;
     taskManager2.creatorHatIds = [BigInt.fromI32(2001)];
+    taskManager2.organizerHatIds = [];
     taskManager2.createdAt = BigInt.fromI32(2000);
     taskManager2.createdAtBlock = BigInt.fromI32(200);
     taskManager2.transactionHash = Bytes.fromHexString("0xdcba");
@@ -1001,5 +1012,152 @@ describe("TaskManager", () => {
     let expectedProject2Id = "0xb27182f471e4948107dc771caf2d6c2f28fc3d3b-0x0000000000000000000000000000000000000000000000000000000000000001";
     assert.fieldEquals("Task", expectedTask2Id, "payout", "200");
     assert.fieldEquals("Task", expectedTask2Id, "project", expectedProject2Id);
+  });
+
+  // ========================================
+  // FoldersUpdated Tests (TaskManager v4)
+  // ========================================
+
+  test("FoldersUpdated stores root on Organization and creates FolderRootChange", () => {
+    setupTaskManagerEntities();
+
+    let orgId = "0x1111111111111111111111111111111111111111111111111111111111111111";
+    let newRoot = Bytes.fromHexString("0xaaaa000000000000000000000000000000000000000000000000000000000001");
+    let oldRoot = Bytes.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000000");
+    let sender = Address.fromString("0x00000000000000000000000000000000000000ff");
+
+    let event = createFoldersUpdatedEvent(newRoot, oldRoot, sender);
+    handleFoldersUpdated(event);
+
+    assert.fieldEquals("Organization", orgId, "foldersRoot", newRoot.toHexString());
+    assert.fieldEquals("Organization", orgId, "foldersUpdatedBy", sender.toHexString());
+    assert.entityCount("FolderRootChange", 1);
+  });
+
+  test("FoldersUpdated chains revisions via oldRoot", () => {
+    setupTaskManagerEntities();
+
+    let root1 = Bytes.fromHexString("0xaaaa000000000000000000000000000000000000000000000000000000000001");
+    let root2 = Bytes.fromHexString("0xbbbb000000000000000000000000000000000000000000000000000000000002");
+    let zero = Bytes.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000000");
+    let sender = Address.fromString("0x00000000000000000000000000000000000000ff");
+
+    // Distinct logIndex so each FolderRootChange (immutable, ID=txHash-logIndex) is unique.
+    let event1 = createFoldersUpdatedEvent(root1, zero, sender);
+    event1.logIndex = BigInt.fromI32(1);
+    handleFoldersUpdated(event1);
+    let event2 = createFoldersUpdatedEvent(root2, root1, sender);
+    event2.logIndex = BigInt.fromI32(2);
+    handleFoldersUpdated(event2);
+
+    let orgId = "0x1111111111111111111111111111111111111111111111111111111111111111";
+    assert.fieldEquals("Organization", orgId, "foldersRoot", root2.toHexString());
+    assert.entityCount("FolderRootChange", 2);
+  });
+
+  // ========================================
+  // OrganizerHatAllowed Tests (TaskManager v4)
+  // ========================================
+
+  test("OrganizerHatAllowed adds hat to organizerHatIds when allowed=true", () => {
+    setupTaskManagerEntities();
+
+    let tmAddr = "0xa16081f360e3847006db660bae1c6d1b2e17ec2a";
+    let hatId = BigInt.fromI32(42);
+
+    handleOrganizerHatAllowed(createOrganizerHatAllowedEvent(hatId, true));
+
+    assert.fieldEquals("TaskManager", tmAddr, "organizerHatIds", "[42]");
+  });
+
+  test("OrganizerHatAllowed is idempotent on duplicate add", () => {
+    setupTaskManagerEntities();
+
+    let tmAddr = "0xa16081f360e3847006db660bae1c6d1b2e17ec2a";
+    let hatId = BigInt.fromI32(42);
+
+    handleOrganizerHatAllowed(createOrganizerHatAllowedEvent(hatId, true));
+    handleOrganizerHatAllowed(createOrganizerHatAllowedEvent(hatId, true));
+
+    assert.fieldEquals("TaskManager", tmAddr, "organizerHatIds", "[42]");
+  });
+
+  test("OrganizerHatAllowed removes hat when allowed=false", () => {
+    setupTaskManagerEntities();
+
+    let tmAddr = "0xa16081f360e3847006db660bae1c6d1b2e17ec2a";
+    let hat1 = BigInt.fromI32(42);
+    let hat2 = BigInt.fromI32(43);
+
+    handleOrganizerHatAllowed(createOrganizerHatAllowedEvent(hat1, true));
+    handleOrganizerHatAllowed(createOrganizerHatAllowedEvent(hat2, true));
+    handleOrganizerHatAllowed(createOrganizerHatAllowedEvent(hat1, false));
+
+    assert.fieldEquals("TaskManager", tmAddr, "organizerHatIds", "[43]");
+  });
+
+  test("OrganizerHatAllowed remove on absent hat is a no-op", () => {
+    setupTaskManagerEntities();
+
+    let tmAddr = "0xa16081f360e3847006db660bae1c6d1b2e17ec2a";
+    let hatId = BigInt.fromI32(42);
+
+    handleOrganizerHatAllowed(createOrganizerHatAllowedEvent(hatId, false));
+
+    assert.fieldEquals("TaskManager", tmAddr, "organizerHatIds", "[]");
+  });
+
+  // ========================================
+  // RolePermSet (Global) Tests (TaskManager v4)
+  // ========================================
+
+  test("RolePermSet creates GlobalRolePermission with all 6 bits decoded", () => {
+    setupTaskManagerEntities();
+
+    let hatId = BigInt.fromI32(1001);
+    let mask: i32 = 63; // 0b111111 = all bits
+
+    handleRolePermSet(createRolePermSetEvent(hatId, mask));
+
+    let id = "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-1001";
+    assert.entityCount("GlobalRolePermission", 1);
+    assert.fieldEquals("GlobalRolePermission", id, "mask", "63");
+    assert.fieldEquals("GlobalRolePermission", id, "canCreate", "true");
+    assert.fieldEquals("GlobalRolePermission", id, "canClaim", "true");
+    assert.fieldEquals("GlobalRolePermission", id, "canReview", "true");
+    assert.fieldEquals("GlobalRolePermission", id, "canAssign", "true");
+    assert.fieldEquals("GlobalRolePermission", id, "canSelfReview", "true");
+    assert.fieldEquals("GlobalRolePermission", id, "canBudget", "true");
+  });
+
+  test("RolePermSet decodes BUDGET-only mask (32)", () => {
+    setupTaskManagerEntities();
+
+    let hatId = BigInt.fromI32(1002);
+    let mask: i32 = 32; // BUDGET only
+
+    handleRolePermSet(createRolePermSetEvent(hatId, mask));
+
+    let id = "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-1002";
+    assert.fieldEquals("GlobalRolePermission", id, "canCreate", "false");
+    assert.fieldEquals("GlobalRolePermission", id, "canClaim", "false");
+    assert.fieldEquals("GlobalRolePermission", id, "canReview", "false");
+    assert.fieldEquals("GlobalRolePermission", id, "canAssign", "false");
+    assert.fieldEquals("GlobalRolePermission", id, "canSelfReview", "false");
+    assert.fieldEquals("GlobalRolePermission", id, "canBudget", "true");
+  });
+
+  test("RolePermSet revoke (mask=0) is preserved verbatim, not deleted", () => {
+    setupTaskManagerEntities();
+
+    let hatId = BigInt.fromI32(1003);
+
+    handleRolePermSet(createRolePermSetEvent(hatId, 32)); // grant BUDGET
+    handleRolePermSet(createRolePermSetEvent(hatId, 0)); // revoke
+
+    let id = "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-1003";
+    assert.entityCount("GlobalRolePermission", 1); // not deleted
+    assert.fieldEquals("GlobalRolePermission", id, "mask", "0");
+    assert.fieldEquals("GlobalRolePermission", id, "canBudget", "false");
   });
 });

--- a/pop-subgraph/tests/task-manager.test.ts
+++ b/pop-subgraph/tests/task-manager.test.ts
@@ -599,6 +599,9 @@ describe("TaskManager", () => {
     assert.fieldEquals("ProjectRolePermission", expectedId, "canClaim", "true");
     assert.fieldEquals("ProjectRolePermission", expectedId, "canReview", "true");
     assert.fieldEquals("ProjectRolePermission", expectedId, "canAssign", "true");
+    // mask=15 has bits 16 and 32 unset
+    assert.fieldEquals("ProjectRolePermission", expectedId, "canSelfReview", "false");
+    assert.fieldEquals("ProjectRolePermission", expectedId, "canBudget", "false");
   });
 
   test("ProjectRolePermSet creates permission with no permissions (mask=0)", () => {
@@ -627,6 +630,55 @@ describe("TaskManager", () => {
     assert.fieldEquals("ProjectRolePermission", expectedId, "canClaim", "false");
     assert.fieldEquals("ProjectRolePermission", expectedId, "canReview", "false");
     assert.fieldEquals("ProjectRolePermission", expectedId, "canAssign", "false");
+    assert.fieldEquals("ProjectRolePermission", expectedId, "canSelfReview", "false");
+    assert.fieldEquals("ProjectRolePermission", expectedId, "canBudget", "false");
+  });
+
+  test("ProjectRolePermSet decodes per-project BUDGET-only mask (32) — v4", () => {
+    setupTaskManagerEntities();
+
+    let projectId = Bytes.fromHexString(
+      "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    );
+    handleProjectCreated(createProjectCreatedEvent(
+      projectId,
+      Bytes.fromHexString("0xabcd"),
+      Bytes.fromHexString("0x0000000000000000000000000000000000000000000000000000000000001234"),
+      BigInt.fromI32(1000)
+    ));
+
+    // mask=32 = TaskPerm.BUDGET only — granted per-project (overrides any global mask).
+    handleProjectRolePermSet(createProjectRolePermSetEvent(projectId, BigInt.fromI32(2001), 32));
+
+    let id = "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef-2001";
+    assert.fieldEquals("ProjectRolePermission", id, "mask", "32");
+    assert.fieldEquals("ProjectRolePermission", id, "canCreate", "false");
+    assert.fieldEquals("ProjectRolePermission", id, "canClaim", "false");
+    assert.fieldEquals("ProjectRolePermission", id, "canReview", "false");
+    assert.fieldEquals("ProjectRolePermission", id, "canAssign", "false");
+    assert.fieldEquals("ProjectRolePermission", id, "canSelfReview", "false");
+    assert.fieldEquals("ProjectRolePermission", id, "canBudget", "true");
+  });
+
+  test("ProjectRolePermSet decodes per-project SELF_REVIEW-only mask (16) — v4", () => {
+    setupTaskManagerEntities();
+
+    let projectId = Bytes.fromHexString(
+      "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    );
+    handleProjectCreated(createProjectCreatedEvent(
+      projectId,
+      Bytes.fromHexString("0xabcd"),
+      Bytes.fromHexString("0x0000000000000000000000000000000000000000000000000000000000001234"),
+      BigInt.fromI32(1000)
+    ));
+
+    handleProjectRolePermSet(createProjectRolePermSetEvent(projectId, BigInt.fromI32(2002), 16));
+
+    let id = "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef-2002";
+    assert.fieldEquals("ProjectRolePermission", id, "canSelfReview", "true");
+    assert.fieldEquals("ProjectRolePermission", id, "canBudget", "false");
+    assert.fieldEquals("ProjectRolePermission", id, "canCreate", "false");
   });
 
   test("ProjectRolePermSet decodes individual permission bits correctly", () => {
@@ -655,6 +707,8 @@ describe("TaskManager", () => {
     assert.fieldEquals("ProjectRolePermission", expectedId, "canClaim", "false");
     assert.fieldEquals("ProjectRolePermission", expectedId, "canReview", "true");
     assert.fieldEquals("ProjectRolePermission", expectedId, "canAssign", "false");
+    assert.fieldEquals("ProjectRolePermission", expectedId, "canSelfReview", "false");
+    assert.fieldEquals("ProjectRolePermission", expectedId, "canBudget", "false");
   });
 
   test("ProjectRolePermSet updates existing permission", () => {

--- a/pop-subgraph/tests/toggle-module.test.ts
+++ b/pop-subgraph/tests/toggle-module.test.ts
@@ -70,6 +70,7 @@ function setupToggleModuleEntities(): void {
   let taskManager = new TaskManager(taskManagerAddress);
   taskManager.organization = orgId;
   taskManager.creatorHatIds = [BigInt.fromI32(1002)]; // Non-member roles that can create projects
+  taskManager.organizerHatIds = []; // populated by OrganizerHatAllowed events (v4)
   taskManager.createdAt = BigInt.fromI32(1000);
   taskManager.createdAtBlock = BigInt.fromI32(100);
   taskManager.transactionHash = Bytes.fromHexString("0xabcd");


### PR DESCRIPTION
## Summary

Indexes the three new TaskManager v4 events from poa-box/POP#159 (branch `hudsonhrh/edit-project-budget`, not yet merged). The v4 upgrade hasn't broadcast to mainnet yet — this readies the indexer so it picks up state from the upgrade block forward.

| Event | Storage |
| --- | --- |
| `FoldersUpdated(newRoot, oldRoot, sender)` | `Organization.foldersRoot` (Bytes) + `foldersUpdatedAt`/`By` + immutable `FolderRootChange` revision log |
| `OrganizerHatAllowed(hatId, allowed)` | `TaskManager.organizerHatIds: [BigInt!]!` (denormalized, mirrors on-chain array) |
| `RolePermSet(hatId, mask)` | New `GlobalRolePermission` entity keyed by `(taskManager, hatId)`, decodes all 6 `TaskPerm` bits including SELF_REVIEW (16) and BUDGET (32) |

### Design notes
- `foldersRoot` is the raw bytes32 sha256 digest of a CIDv0; the frontend prepends `0x1220` and base58-encodes to fetch IPFS. Subgraph does not resolve the folder-tree JSON itself.
- `organizerHatIds` mirrors `creatorHatIds` (same shape, parallel field on TaskManager).
- `GlobalRolePermission` is intentionally distinct from the existing per-project `ProjectRolePermission` so frontends can query "who has BUDGET globally on this org" vs "who has BUDGET on this project" cleanly.
- `RolePermSet` with `mask=0` (revoke) writes the entity with `mask=0` rather than deleting — distinguishes "never granted" (no entity) from "explicitly revoked".
- ABI was hand-edited to insert the three new event entries in alphabetical order, following the precedent of #173.

### Schema compatibility
All schema changes are additive: new fields on `Organization` are nullable; the new non-null `TaskManager.organizerHatIds` is initialized to \`[]\` in \`handleOrgDeployed\`. Test setup helpers across 5 test files were updated to seed it.

## Test plan

- [x] \`yarn codegen\` clean
- [x] \`yarn build\` clean (Gnosis manifest; \`--network arbitrum-one\` not run here, deps are network-agnostic)
- [x] \`yarn test\` — 250/250 pass (9 new tests covering all three handlers, including idempotent add, revoke-as-mask-0, all-bits-set, BUDGET-only)
- [x] \`subgraph-lint\` — 0 errors (9 pre-existing warnings in \`poa-manager.ts\`, unrelated)
- [ ] Deploy to Graph Studio (Gnosis + Arbitrum) — pending the v4 broadcast; sanity query against the test org \`0x9c22ff5f21f0b81b113e63f7db6da94fedef11b2119b4088b89664fb9a3cb658\` should return null/empty values until then.

Closes #174
Closes #175
Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)