### PR TITLE
feat(quick-join): index memberHatIds on QuickJoinContract entity

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -962,6 +962,9 @@ type QuickJoinContract @entity(immutable: false) {
   accountRegistry: Bytes!
   masterDeployAddress: Bytes!
   universalFactory: Bytes # PasskeyAccountFactory address for passkey joins
+  # Hats anyone can claim via quickJoinWithUser without vouching. Mirrors the
+  # on-chain QuickJoin.memberHatIds() array; updated by MemberHatIdsUpdated.
+  memberHatIds: [BigInt!]!
   createdAt: BigInt!
   createdAtBlock: BigInt!
   joinEvents: [QuickJoinEvent!]! @derivedFrom(field: "quickJoin")

--- a/pop-subgraph/src/org-deployer.ts
+++ b/pop-subgraph/src/org-deployer.ts
@@ -106,6 +106,7 @@ export function handleOrgDeployed(event: OrgDeployed): void {
   quickJoin.hatsContract = Address.zero(); // Will be set by Initialized event
   quickJoin.accountRegistry = Address.zero(); // Will be set by Initialized event
   quickJoin.masterDeployAddress = Address.zero(); // Will be set by Initialized event
+  quickJoin.memberHatIds = []; // Populated by MemberHatIdsUpdated event
   quickJoin.createdAt = event.block.timestamp;
   quickJoin.createdAtBlock = event.block.number;
 

--- a/pop-subgraph/src/quick-join.ts
+++ b/pop-subgraph/src/quick-join.ts
@@ -184,6 +184,13 @@ export function handleMemberHatIdsUpdated(event: MemberHatIdsUpdatedEvent): void
 
   let hatIds = event.params.hatIds;
 
+  // Persist the full member-hat list on the contract entity. This is the
+  // source of truth for "which hats can be claimed via quickJoinWithUser
+  // without vouching" and replaces the on-chain memberHatIds() call the
+  // frontend currently makes from useOrgStructure.
+  contract.memberHatIds = hatIds;
+  contract.save();
+
   // Update all member hats based on the new list
   for (let i = 0; i < hatIds.length; i++) {
     let hatId = hatIds[i];

--- a/pop-subgraph/tests/eligibility-module.test.ts
+++ b/pop-subgraph/tests/eligibility-module.test.ts
@@ -152,6 +152,7 @@ function setupEligibilityModuleEntities(): void {
   quickJoin.hatsContract = Address.zero();
   quickJoin.accountRegistry = Address.zero();
   quickJoin.masterDeployAddress = Address.zero();
+  quickJoin.memberHatIds = [];
   quickJoin.createdAt = BigInt.fromI32(1000);
   quickJoin.createdAtBlock = BigInt.fromI32(100);
 

--- a/pop-subgraph/tests/executor.test.ts
+++ b/pop-subgraph/tests/executor.test.ts
@@ -147,6 +147,7 @@ function setupExecutorEntities(): void {
   quickJoin.hatsContract = Address.zero();
   quickJoin.accountRegistry = Address.zero();
   quickJoin.masterDeployAddress = Address.zero();
+  quickJoin.memberHatIds = [];
   quickJoin.createdAt = BigInt.fromI32(1000);
   quickJoin.createdAtBlock = BigInt.fromI32(100);
 

--- a/pop-subgraph/tests/hybrid-voting.test.ts
+++ b/pop-subgraph/tests/hybrid-voting.test.ts
@@ -134,6 +134,7 @@ function setupHybridVotingContract(contractAddress: Address): void {
   quickJoin.hatsContract = Address.zero();
   quickJoin.accountRegistry = Address.zero();
   quickJoin.masterDeployAddress = Address.zero();
+  quickJoin.memberHatIds = [];
   quickJoin.createdAt = BigInt.fromI32(1000);
   quickJoin.createdAtBlock = BigInt.fromI32(100);
 

--- a/pop-subgraph/tests/quick-join-utils.ts
+++ b/pop-subgraph/tests/quick-join-utils.ts
@@ -1,10 +1,24 @@
 import { newMockEvent } from "matchstick-as";
 import { ethereum, Address, BigInt, Bytes } from "@graphprotocol/graph-ts";
 import {
+  MemberHatIdsUpdated,
   RegisterAndQuickJoined,
   RegisterAndQuickJoinedWithPasskey,
   RegisterAndQuickJoinedWithPasskeyByMaster
 } from "../generated/templates/QuickJoin/QuickJoin";
+
+export function createMemberHatIdsUpdatedEvent(
+  hatIds: BigInt[]
+): MemberHatIdsUpdated {
+  let event = changetype<MemberHatIdsUpdated>(newMockEvent());
+
+  event.parameters = new Array();
+  event.parameters.push(
+    new ethereum.EventParam("hatIds", ethereum.Value.fromUnsignedBigIntArray(hatIds))
+  );
+
+  return event;
+}
 
 export function createRegisterAndQuickJoinedEvent(
   user: Address,

--- a/pop-subgraph/tests/quick-join.test.ts
+++ b/pop-subgraph/tests/quick-join.test.ts
@@ -7,11 +7,13 @@ import {
 } from "matchstick-as/assembly/index";
 import { Address, Bytes, BigInt } from "@graphprotocol/graph-ts";
 import {
+  handleMemberHatIdsUpdated,
   handleRegisterAndQuickJoined,
   handleRegisterAndQuickJoinedWithPasskey,
   handleRegisterAndQuickJoinedWithPasskeyByMaster
 } from "../src/quick-join";
 import {
+  createMemberHatIdsUpdatedEvent,
   createRegisterAndQuickJoinedEvent,
   createRegisterAndQuickJoinedWithPasskeyEvent,
   createRegisterAndQuickJoinedWithPasskeyByMasterEvent
@@ -44,6 +46,7 @@ function setupQuickJoinEntities(): void {
   quickJoin.hatsContract = Address.zero();
   quickJoin.accountRegistry = Address.zero();
   quickJoin.masterDeployAddress = Address.zero();
+  quickJoin.memberHatIds = [];
   quickJoin.createdAt = BigInt.fromI32(1000);
   quickJoin.createdAtBlock = BigInt.fromI32(100);
 
@@ -154,6 +157,43 @@ describe("QuickJoin - Register and Join", () => {
       assert.fieldEquals("PasskeyQuickJoin", eventId, "username", "charlie");
       assert.fieldEquals("PasskeyQuickJoin", eventId, "quickJoinContract", QUICK_JOIN_ADDRESS.toHexString());
       assert.fieldEquals("PasskeyQuickJoin", eventId, "credentialId", credentialId.toHexString());
+    });
+  });
+
+  describe("handleMemberHatIdsUpdated", () => {
+    // Use unmocked-event sender so QUICK_JOIN_ADDRESS matches the entity created
+    // in setupQuickJoinEntities (newMockEvent's default address).
+    test("persists the hat list onto QuickJoinContract.memberHatIds", () => {
+      setupQuickJoinEntities();
+
+      let hatIds: BigInt[] = [BigInt.fromI32(1001), BigInt.fromI32(1002), BigInt.fromI32(1003)];
+
+      let event = createMemberHatIdsUpdatedEvent(hatIds);
+      handleMemberHatIdsUpdated(event);
+
+      assert.fieldEquals(
+        "QuickJoinContract",
+        QUICK_JOIN_ADDRESS.toHexString(),
+        "memberHatIds",
+        "[1001, 1002, 1003]"
+      );
+    });
+
+    test("overwrites previous list when called again", () => {
+      setupQuickJoinEntities();
+
+      let first = createMemberHatIdsUpdatedEvent([BigInt.fromI32(1001), BigInt.fromI32(1002)]);
+      handleMemberHatIdsUpdated(first);
+
+      let second = createMemberHatIdsUpdatedEvent([BigInt.fromI32(2001)]);
+      handleMemberHatIdsUpdated(second);
+
+      assert.fieldEquals(
+        "QuickJoinContract",
+        QUICK_JOIN_ADDRESS.toHexString(),
+        "memberHatIds",
+        "[2001]"
+      );
     });
   });
 });

--- a/pop-subgraph/tests/task-manager.test.ts
+++ b/pop-subgraph/tests/task-manager.test.ts
@@ -139,6 +139,7 @@ function setupTaskManagerEntities(): void {
   quickJoin.hatsContract = Address.zero();
   quickJoin.accountRegistry = Address.zero();
   quickJoin.masterDeployAddress = Address.zero();
+  quickJoin.memberHatIds = [];
   quickJoin.createdAt = BigInt.fromI32(1000);
   quickJoin.createdAtBlock = BigInt.fromI32(100);
 

--- a/pop-subgraph/tests/toggle-module.test.ts
+++ b/pop-subgraph/tests/toggle-module.test.ts
@@ -129,6 +129,7 @@ function setupToggleModuleEntities(): void {
   quickJoin.hatsContract = Address.zero();
   quickJoin.accountRegistry = Address.zero();
   quickJoin.masterDeployAddress = Address.zero();
+  quickJoin.memberHatIds = [];
   quickJoin.createdAt = BigInt.fromI32(1000);
   quickJoin.createdAtBlock = BigInt.fromI32(100);
 


### PR DESCRIPTION
## Summary

- Adds `QuickJoinContract.memberHatIds: [BigInt!]!` to the schema and writes it from the existing `MemberHatIdsUpdated` handler.
- Initializes the field to `[]` at entity creation in `org-deployer.ts`.
- Updates the five sibling fixtures that build `QuickJoinContract` (executor, hybrid-voting, task-manager, toggle-module, eligibility-module) plus `quick-join.test.ts` itself so the non-null field is satisfied, and adds two focused tests covering initial-write and overwrite-on-update semantics.

## Why

`QuickJoin.memberHatIds()` is the list of hats anyone can claim via `quickJoinWithUser` without vouching. The poa-frontend currently reads it directly from the chain in `useOrgStructure` because the subgraph didn't index it — this means every org-structure load does an extra RPC round-trip and Apollo can't cache the result.

Indexing the field lets us drop that on-chain read once consumers migrate, and it keeps the field's source of truth aligned with how other QuickJoin state is exposed.

## Test plan

- [x] `npm run codegen` — clean
- [x] `npm run build` — clean
- [x] `npm run test` — all 254 tests pass (252 existing + 2 new in `quick-join.test.ts`)
- [ ] After merge: redeploy subgraph to Gnosis (and Arbitrum if applicable), then remove the `memberHatIds()` on-chain read in `useOrgStructure.js` on the frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)