### PR TITLE
feat(eligibility-module): surface governance-created hats in org.roleHatIds

### DIFF
--- a/pop-subgraph/src/eligibility-module.ts
+++ b/pop-subgraph/src/eligibility-module.ts
@@ -26,6 +26,8 @@ import {
   EligibilityModuleContract,
   Hat,
   HatMetadata,
+  Organization,
+  Role,
   WearerEligibility,
   VouchConfig,
   Vouch,
@@ -162,8 +164,38 @@ export function handleHatCreatedWithEligibility(
   // Link Hat to Role entity + populate HatLookup.hat so HatStatusChanged
   // can resolve hatId -> Hat entity.
   if (eligibilityModule) {
-    linkHatToRole(eligibilityModule.organization, hatId, hatEntityId, event);
+    let role = linkHatToRole(eligibilityModule.organization, hatId, hatEntityId, event);
     linkHatToLookup(hatId, eligibilityModule.organization, hatEntityId);
+
+    // Genesis hats are minted via Hats.createHat in Deployer.sol (no
+    // HatCreatedWithEligibility emitted). Every HatCreatedWithEligibility we
+    // see post-genesis is a governance-created user role — surface it to the
+    // org's role list so the frontend's role pickers, permission UI and
+    // member sidebar pick it up without a redeploy.
+    let org = Organization.load(eligibilityModule.organization);
+    if (org) {
+      let existing = org.roleHatIds;
+      let alreadyTracked = false;
+      if (existing) {
+        for (let i = 0; i < existing.length; i++) {
+          if (existing[i].equals(hatId)) {
+            alreadyTracked = true;
+            break;
+          }
+        }
+      }
+      if (!alreadyTracked) {
+        let updated = existing ? existing : new Array<BigInt>(0);
+        updated.push(hatId);
+        org.roleHatIds = updated;
+        org.lastUpdatedAt = event.block.timestamp;
+        org.save();
+      }
+      if (role.isUserRole != true) {
+        role.isUserRole = true;
+        role.save();
+      }
+    }
   }
 }
 

--- a/pop-subgraph/tests/eligibility-module.test.ts
+++ b/pop-subgraph/tests/eligibility-module.test.ts
@@ -496,6 +496,38 @@ describe("EligibilityModule - DefaultEligibilityUpdated", () => {
     let roleId = orgId.toHexString() + "-" + newHatId.toString();
     assert.entityCount("Role", 1);
     assert.fieldEquals("Role", roleId, "hat", hatEntityId);
+
+    // Governance-created hats join the org's role list so the frontend
+    // surfaces them in role pickers without a redeploy.
+    assert.fieldEquals(
+      "Organization",
+      orgId.toHexString(),
+      "roleHatIds",
+      "[1001, 1002, 3001]"
+    );
+    assert.fieldEquals("Role", roleId, "isUserRole", "true");
+  });
+
+  test("HatCreatedWithEligibility is idempotent on roleHatIds", () => {
+    setupEligibilityModuleEntities();
+
+    let creator = Address.fromString("0x0000000000000000000000000000000000000099");
+    let parentHatId = BigInt.fromI32(1000);
+    let newHatId = BigInt.fromI32(3001);
+
+    let event = createHatCreatedWithEligibilityEvent(
+      creator, parentHatId, newHatId, true, true, BigInt.fromI32(0)
+    );
+    handleHatCreatedWithEligibility(event);
+    handleHatCreatedWithEligibility(event);
+
+    let orgId = Bytes.fromHexString("0x1111111111111111111111111111111111111111111111111111111111111111");
+    assert.fieldEquals(
+      "Organization",
+      orgId.toHexString(),
+      "roleHatIds",
+      "[1001, 1002, 3001]"
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- `handleHatCreatedWithEligibility` now appends the new hatId to `Organization.roleHatIds` (deduped) and flips the linked `Role.isUserRole = true`.
- Lets the frontend's role pickers, permission UI and member sidebar pick up post-genesis governance-created roles without a redeploy.
- Two new matchstick tests cover the append behavior + idempotency on replay.

## Why this is safe
Genesis hats are minted via `Hats.createHat` directly in `Deployer.sol` — no `HatCreatedWithEligibility` event emitted. The event is only fired from `EligibilityModule.createHatWithEligibility`, which is gated by `onlyHatAdmin`. Post-deployment the only caller with admin rights is the Executor (it's the EligibilityModule's `superAdmin` — see `Deployer.sol:521`), and the Executor is only invoked via governance votes. So every `HatCreatedWithEligibility` we index is, by construction, a governance-created user role.

## Companion changes
- Frontend: poa-box/Poa-frontend#418 — adds the `createRole` governance proposal type that emits these events.
- Contracts (longer-term): poa-box/POP#166 — `Executor.createRoleAndConfigure` helper that eliminates the off-chain hatId-prediction race the frontend currently works around.

## Test plan
- [ ] `yarn codegen && yarn build` clean
- [ ] `yarn test eligibility-module` passes (14 tests total, including 2 new)
- [ ] Deploy to Gnosis subgraph; submit a `createRole` proposal via the frontend PR; verify the new hat appears in `Organization.roleHatIds` after execution
- [ ] Verify `Role.isUserRole = true` on the new role entity

🤖 Generated with [Claude Code](https://claude.com/claude-code)