### PR TITLE
feat(eligibility-module): extract Role.name + image from Hats.viewHat

### DIFF
--- a/pop-subgraph/abis/Hats.json
+++ b/pop-subgraph/abis/Hats.json
@@ -31,5 +31,25 @@
     ],
     "name": "HatStatusChanged",
     "type": "event"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_hatId", "type": "uint256" }
+    ],
+    "name": "viewHat",
+    "outputs": [
+      { "internalType": "string", "name": "details", "type": "string" },
+      { "internalType": "uint32", "name": "maxSupply", "type": "uint32" },
+      { "internalType": "uint32", "name": "supply", "type": "uint32" },
+      { "internalType": "address", "name": "eligibility", "type": "address" },
+      { "internalType": "address", "name": "toggle", "type": "address" },
+      { "internalType": "string", "name": "imageURI", "type": "string" },
+      { "internalType": "uint16", "name": "lastHatId", "type": "uint16" },
+      { "internalType": "uint8", "name": "level", "type": "uint8" },
+      { "internalType": "bool", "name": "active", "type": "bool" },
+      { "internalType": "bool", "name": "mutable_", "type": "bool" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/pop-subgraph/src/eligibility-module.ts
+++ b/pop-subgraph/src/eligibility-module.ts
@@ -1,5 +1,6 @@
 import { Address, BigInt, Bytes, DataSourceContext, log } from "@graphprotocol/graph-ts";
 import { HatMetadata as HatMetadataTemplate } from "../generated/templates";
+import { Hats } from "../generated/Hats/Hats";
 import {
   EligibilityModuleInitialized as EligibilityModuleInitializedEvent,
   HatCreatedWithEligibility as HatCreatedWithEligibilityEvent,
@@ -159,6 +160,36 @@ export function handleHatCreatedWithEligibility(
   hat.createdAtBlock = event.block.number;
   hat.transactionHash = event.transaction.hash;
 
+  // Pull the role name + image off Hats Protocol. createHatWithEligibility
+  // passes the name/image as the `details`/`imageURI` args to Hats.createHat,
+  // but the EligibilityModule's HatCreatedWithEligibility event doesn't carry
+  // them — it only carries the new hatId and default flags. Without a read
+  // here, governance-created roles render as placeholder "Role N" in the
+  // frontend (the deployer wizard's roles get names from a separate
+  // RolesCreated event that createRole proposals don't emit).
+  //
+  // We use the EligibilityModule's stored hatsContract address rather than
+  // hardcoding it. If the contract call reverts (very unlikely — the hat was
+  // just created in the same tx), we leave name/image null and the frontend
+  // falls back to its existing "Role N" placeholder; the role still appears.
+  let roleName: string | null = null;
+  let roleImage: string | null = null;
+  if (eligibilityModule) {
+    let hatsContract = Hats.bind(Address.fromBytes(eligibilityModule.hatsContract));
+    let viewResult = hatsContract.try_viewHat(hatId);
+    if (!viewResult.reverted) {
+      let details = viewResult.value.getDetails();
+      let imageURI = viewResult.value.getImageURI();
+      if (details.length > 0) {
+        hat.name = details;
+        roleName = details;
+      }
+      if (imageURI.length > 0) {
+        roleImage = imageURI;
+      }
+    }
+  }
+
   hat.save();
 
   // Link Hat to Role entity + populate HatLookup.hat so HatStatusChanged
@@ -191,10 +222,25 @@ export function handleHatCreatedWithEligibility(
         org.lastUpdatedAt = event.block.timestamp;
         org.save();
       }
+      // Update Role.isUserRole + name/image. We always overwrite name/image
+      // when viewHat returned a non-empty value: createHatWithEligibility is
+      // the authoritative source for those fields at creation time, and we
+      // shouldn't keep stale nulls if a prior call (e.g. handler ordering)
+      // created the Role entity without them.
+      let roleChanged = false;
       if (role.isUserRole != true) {
         role.isUserRole = true;
-        role.save();
+        roleChanged = true;
       }
+      if (roleName !== null && role.name != roleName) {
+        role.name = roleName;
+        roleChanged = true;
+      }
+      if (roleImage !== null && role.image != roleImage) {
+        role.image = roleImage;
+        roleChanged = true;
+      }
+      if (roleChanged) role.save();
     }
   }
 }

--- a/pop-subgraph/tests/eligibility-module.test.ts
+++ b/pop-subgraph/tests/eligibility-module.test.ts
@@ -3,9 +3,10 @@ import {
   describe,
   test,
   clearStore,
-  afterEach
+  afterEach,
+  createMockedFunction
 } from "matchstick-as/assembly/index";
-import { Address, Bytes, BigInt } from "@graphprotocol/graph-ts";
+import { Address, Bytes, BigInt, ethereum } from "@graphprotocol/graph-ts";
 
 /**
  * Helper function to convert bytes32 sha256 digest to IPFS CIDv0.
@@ -202,6 +203,39 @@ function setupEligibilityModuleEntities(): void {
   educationHub.save();
   paymentManager.save();
   organization.save();
+}
+
+/**
+ * Stub Hats.viewHat(hatId) at the given Hats contract address. The handler
+ * calls try_viewHat for every HatCreatedWithEligibility event to pull the
+ * role name + image off chain; matchstick fails the test if the call has no
+ * mock, so every test that exercises handleHatCreatedWithEligibility needs
+ * one. Pass empty strings to keep the default "no name extracted" behavior.
+ */
+function mockViewHat(
+  hatsAddress: Address,
+  hatId: BigInt,
+  details: string,
+  imageURI: string
+): void {
+  createMockedFunction(
+    hatsAddress,
+    "viewHat",
+    "viewHat(uint256):(string,uint32,uint32,address,address,string,uint16,uint8,bool,bool)"
+  )
+    .withArgs([ethereum.Value.fromUnsignedBigInt(hatId)])
+    .returns([
+      ethereum.Value.fromString(details),
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(1)),
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(0)),
+      ethereum.Value.fromAddress(Address.zero()),
+      ethereum.Value.fromAddress(Address.zero()),
+      ethereum.Value.fromString(imageURI),
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(0)),
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(1)),
+      ethereum.Value.fromBoolean(true),
+      ethereum.Value.fromBoolean(true)
+    ]);
 }
 
 /**
@@ -476,6 +510,10 @@ describe("EligibilityModule - DefaultEligibilityUpdated", () => {
     let parentHatId = BigInt.fromI32(1000);
     let newHatId = BigInt.fromI32(3001);
 
+    // Setup defaults hatsContract to Address.zero(); empty viewHat result
+    // means the handler leaves name/image untouched.
+    mockViewHat(Address.zero(), newHatId, "", "");
+
     let event = createHatCreatedWithEligibilityEvent(
       creator,
       parentHatId,
@@ -516,6 +554,8 @@ describe("EligibilityModule - DefaultEligibilityUpdated", () => {
     let parentHatId = BigInt.fromI32(1000);
     let newHatId = BigInt.fromI32(3001);
 
+    mockViewHat(Address.zero(), newHatId, "", "");
+
     let event = createHatCreatedWithEligibilityEvent(
       creator, parentHatId, newHatId, true, true, BigInt.fromI32(0)
     );
@@ -529,6 +569,62 @@ describe("EligibilityModule - DefaultEligibilityUpdated", () => {
       "roleHatIds",
       "[1001, 1002, 3001]"
     );
+  });
+
+  test("HatCreatedWithEligibility populates Role.name + image from Hats.viewHat", () => {
+    setupEligibilityModuleEntities();
+
+    // Point the EligibilityModule at a known Hats contract address so the
+    // handler's Hats.bind(eligibilityModule.hatsContract) targets something
+    // we can mock. Setup defaults to Address.zero() which has no mock here.
+    let hatsAddr = Address.fromString("0x000000000000000000000000000000000000abcd");
+    let modAddr = Address.fromString("0xa16081f360e3847006db660bae1c6d1b2e17ec2a");
+    let mod = EligibilityModuleContract.load(modAddr);
+    if (mod) {
+      mod.hatsContract = hatsAddr;
+      mod.save();
+    }
+
+    let creator = Address.fromString("0x0000000000000000000000000000000000000099");
+    let parentHatId = BigInt.fromI32(1000);
+    let newHatId = BigInt.fromI32(3002);
+
+    // Mock Hats.viewHat(3002) → (details="Treasurer", maxSupply=5, supply=0,
+    // eligibility=mod, toggle=0, imageURI="ipfs://logo", lastHatId=0, level=4,
+    // active=true, mutable=true).
+    createMockedFunction(
+      hatsAddr,
+      "viewHat",
+      "viewHat(uint256):(string,uint32,uint32,address,address,string,uint16,uint8,bool,bool)"
+    )
+      .withArgs([ethereum.Value.fromUnsignedBigInt(newHatId)])
+      .returns([
+        ethereum.Value.fromString("Treasurer"),
+        ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(5)),
+        ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(0)),
+        ethereum.Value.fromAddress(modAddr),
+        ethereum.Value.fromAddress(Address.zero()),
+        ethereum.Value.fromString("ipfs://logo"),
+        ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(0)),
+        ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(4)),
+        ethereum.Value.fromBoolean(true),
+        ethereum.Value.fromBoolean(true)
+      ]);
+
+    let event = createHatCreatedWithEligibilityEvent(
+      creator, parentHatId, newHatId, true, true, BigInt.fromI32(0)
+    );
+    handleHatCreatedWithEligibility(event);
+
+    let orgId = Bytes.fromHexString("0x1111111111111111111111111111111111111111111111111111111111111111");
+    let roleId = orgId.toHexString() + "-" + newHatId.toString();
+    let hatEntityId = "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-3002";
+
+    // Name should be picked up on both Hat and Role.
+    assert.fieldEquals("Hat", hatEntityId, "name", "Treasurer");
+    assert.fieldEquals("Role", roleId, "name", "Treasurer");
+    assert.fieldEquals("Role", roleId, "image", "ipfs://logo");
+    assert.fieldEquals("Role", roleId, "isUserRole", "true");
   });
 });
 


### PR DESCRIPTION
## Summary

After #180 surfaced governance-created hats in `org.roleHatIds`, the frontend's role list rendered them as placeholder **"Role 4 / Role 5 / Role 6"** because `Role.name` was null. This PR fixes that by reading the name from Hats Protocol directly inside the existing handler.

### Before / after on Test6

| Before (live now) | After |
|---|---|
| Role 3 (eligibilityAdminHat), Executive, Member, **Role 4**, **Role 5**, **Role 6** | Role 3, Executive, Member, **TaskRunner**, **Newcomer**, **Treasurer** |

## What changed

- `abis/Hats.json` — added `viewHat(uint256)` function fragment (the ABI previously only had events).
- `src/eligibility-module.ts` — in `handleHatCreatedWithEligibility`, bind the Hats contract via `EligibilityModuleContract.hatsContract` and call `try_viewHat(newHatId)`. Pull `details` → `Hat.name` + `Role.name`, `imageURI` → `Role.image`.
- `tests/eligibility-module.test.ts` — 1 new test mocking `viewHat` → asserts both Role fields land; existing tests updated to stub `viewHat` with empty strings (matchstick fails on un-mocked contract calls).

## Why this works

`createHatWithEligibility(CreateHatParams)` already accepts `details` and `imageURI` and forwards them to `Hats.createHat`, but the resulting `HatCreatedWithEligibility` event drops those strings — it only carries `newHatId` + default flags. The data is still on chain in the hat's storage. `Hats.viewHat(newHatId)` returns it. Both calls happen in the same tx as `createHatWithEligibility`, so by the time we index the event the hat's `details` is already set.

Empty `details`/`imageURI` and contract reverts are tolerated (Role keeps null name/image, frontend falls back to its existing "Role N" placeholder).

## Companion

- Frontend createRole proposal type: poa-box/Poa-frontend#418
- Race-condition contracts fix (out-of-scope here): poa-box/POP#166

## Test plan

- [x] `yarn codegen && yarn build` clean
- [x] `yarn test eligibility-module` — 15/15 pass (1 new)
- [x] `yarn test` — 256/256 pass
- [ ] Deploy to Gnosis subgraph; verify `Test6.roles` returns `name: "TaskRunner"` etc. instead of nulls
- [ ] Verify the frontend's `/team?org=Test6` role tree renders the real names

🤖 Generated with [Claude Code](https://claude.com/claude-code)