### PR TITLE
feat(eligibility-module): exclude admin hat from user-facing role list

### DIFF
--- a/pop-subgraph/src/eligibility-module.ts
+++ b/pop-subgraph/src/eligibility-module.ts
@@ -641,8 +641,47 @@ export function handleEligibilityModuleAdminHatSet(
     return;
   }
 
-  contract.eligibilityModuleAdminHat = event.params.hatId;
+  let adminHatId = event.params.hatId;
+  contract.eligibilityModuleAdminHat = adminHatId;
   contract.save();
+
+  // The admin hat is a system hat — its wearer is the EligibilityModule
+  // contract itself, not a user. It shouldn't appear in user-facing role
+  // pickers, the team-page role tree, or the leaderboard. Strip it from
+  // org.roleHatIds and force Role.isUserRole = false so every downstream
+  // consumer skips it cleanly.
+  //
+  // We do this on every admin-hat-set event (typically fires once, at
+  // genesis), so a subgraph re-index from block 0 correctly excludes the
+  // admin hat from already-deployed orgs — no contracts change needed.
+  let orgId = contract.organization;
+  let roleId = orgId.toHexString() + "-" + adminHatId.toString();
+  let role = Role.load(roleId);
+  if (role != null && role.isUserRole != false) {
+    role.isUserRole = false;
+    role.save();
+  }
+
+  let org = Organization.load(orgId);
+  if (org != null) {
+    let existing = org.roleHatIds;
+    if (existing != null && existing.length > 0) {
+      let filtered = new Array<BigInt>(0);
+      let removed = false;
+      for (let i = 0; i < existing.length; i++) {
+        if (existing[i].equals(adminHatId)) {
+          removed = true;
+        } else {
+          filtered.push(existing[i]);
+        }
+      }
+      if (removed) {
+        org.roleHatIds = filtered;
+        org.lastUpdatedAt = event.block.timestamp;
+        org.save();
+      }
+    }
+  }
 }
 
 export function handleGovernanceAdminSet(

--- a/pop-subgraph/tests/eligibility-module-utils.ts
+++ b/pop-subgraph/tests/eligibility-module-utils.ts
@@ -4,9 +4,23 @@ import {
   HatMetadataUpdated,
   HatCreatedWithEligibility,
   DefaultEligibilityUpdated,
+  EligibilityModuleAdminHatSet,
   RoleApplicationSubmitted,
   RoleApplicationWithdrawn
 } from "../generated/templates/EligibilityModule/EligibilityModule";
+
+export function createEligibilityModuleAdminHatSetEvent(
+  hatId: BigInt
+): EligibilityModuleAdminHatSet {
+  let event = changetype<EligibilityModuleAdminHatSet>(newMockEvent());
+
+  event.parameters = new Array();
+  event.parameters.push(
+    new ethereum.EventParam("hatId", ethereum.Value.fromUnsignedBigInt(hatId))
+  );
+
+  return event;
+}
 
 export function createHatMetadataUpdatedEvent(
   hatId: BigInt,

--- a/pop-subgraph/tests/eligibility-module.test.ts
+++ b/pop-subgraph/tests/eligibility-module.test.ts
@@ -26,6 +26,7 @@ import {
   handleHatMetadataUpdated,
   handleHatCreatedWithEligibility,
   handleDefaultEligibilityUpdated,
+  handleEligibilityModuleAdminHatSet,
   handleRoleApplicationSubmitted,
   handleRoleApplicationWithdrawn
 } from "../src/eligibility-module";
@@ -33,6 +34,7 @@ import {
   createHatMetadataUpdatedEvent,
   createHatCreatedWithEligibilityEvent,
   createDefaultEligibilityUpdatedEvent,
+  createEligibilityModuleAdminHatSetEvent,
   createRoleApplicationSubmittedEvent,
   createRoleApplicationWithdrawnEvent
 } from "./eligibility-module-utils";
@@ -528,6 +530,111 @@ describe("EligibilityModule - DefaultEligibilityUpdated", () => {
       orgId.toHexString(),
       "roleHatIds",
       "[1001, 1002, 3001]"
+    );
+  });
+});
+
+describe("EligibilityModule - EligibilityModuleAdminHatSet", () => {
+  afterEach(() => {
+    clearStore();
+  });
+
+  test("Removes admin hat from org.roleHatIds and forces Role.isUserRole = false", () => {
+    setupEligibilityModuleEntities();
+
+    // Simulate the post-PR-#180 state where the admin hat snuck into the
+    // org's role list (this is what Test6 currently looks like — see issue).
+    let orgId = Bytes.fromHexString(
+      "0x1111111111111111111111111111111111111111111111111111111111111111"
+    );
+    let adminHatId = BigInt.fromI32(2500);
+    let org = Organization.load(orgId);
+    if (org) {
+      org.roleHatIds = [BigInt.fromI32(1001), BigInt.fromI32(1002), adminHatId];
+      org.save();
+    }
+
+    // Seed a Role entity for the admin hat with isUserRole=true to mirror
+    // the bad state on Test6. The handler should flip it back to false.
+    let roleId = orgId.toHexString() + "-" + adminHatId.toString();
+    let role = new Role(roleId);
+    role.organization = orgId;
+    role.hatId = adminHatId;
+    role.isUserRole = true;
+    role.createdAt = BigInt.fromI32(1000);
+    role.createdAtBlock = BigInt.fromI32(100);
+    role.transactionHash = Bytes.fromHexString("0xabcd");
+    role.save();
+
+    let event = createEligibilityModuleAdminHatSetEvent(adminHatId);
+    handleEligibilityModuleAdminHatSet(event);
+
+    // Admin hat is stripped from the user-facing role list.
+    assert.fieldEquals(
+      "Organization",
+      orgId.toHexString(),
+      "roleHatIds",
+      "[1001, 1002]"
+    );
+    // And its Role is no longer flagged as user-facing.
+    assert.fieldEquals("Role", roleId, "isUserRole", "false");
+    // The contract entity records the admin hat (for callers that need it).
+    assert.fieldEquals(
+      "EligibilityModuleContract",
+      "0xa16081f360e3847006db660bae1c6d1b2e17ec2a",
+      "eligibilityModuleAdminHat",
+      "2500"
+    );
+  });
+
+  test("Idempotent — running twice leaves state stable", () => {
+    setupEligibilityModuleEntities();
+    let orgId = Bytes.fromHexString(
+      "0x1111111111111111111111111111111111111111111111111111111111111111"
+    );
+    let adminHatId = BigInt.fromI32(2500);
+    let org = Organization.load(orgId);
+    if (org) {
+      org.roleHatIds = [BigInt.fromI32(1001), BigInt.fromI32(1002), adminHatId];
+      org.save();
+    }
+
+    let event = createEligibilityModuleAdminHatSetEvent(adminHatId);
+    handleEligibilityModuleAdminHatSet(event);
+    handleEligibilityModuleAdminHatSet(event);
+
+    assert.fieldEquals(
+      "Organization",
+      orgId.toHexString(),
+      "roleHatIds",
+      "[1001, 1002]"
+    );
+  });
+
+  test("No-op when admin hat isn't in roleHatIds and no Role exists", () => {
+    setupEligibilityModuleEntities();
+    let orgId = Bytes.fromHexString(
+      "0x1111111111111111111111111111111111111111111111111111111111111111"
+    );
+    let adminHatId = BigInt.fromI32(9999);
+    // roleHatIds stays as the setup default [1001, 1002] — admin hat is
+    // not in there, no Role exists for it. The handler should still
+    // record the admin hat on the contract entity without touching org.
+
+    let event = createEligibilityModuleAdminHatSetEvent(adminHatId);
+    handleEligibilityModuleAdminHatSet(event);
+
+    assert.fieldEquals(
+      "Organization",
+      orgId.toHexString(),
+      "roleHatIds",
+      "[1001, 1002]"
+    );
+    assert.fieldEquals(
+      "EligibilityModuleContract",
+      "0xa16081f360e3847006db660bae1c6d1b2e17ec2a",
+      "eligibilityModuleAdminHat",
+      "9999"
     );
   });
 });


### PR DESCRIPTION
## Summary

After #180 surfaced governance-created hats in `org.roleHatIds`, the frontend's role tree on Test6 (poa.box/team?org=Test6) renders **"Role 3"** at the top — that's the EligibilityModule's internal admin hat, whose wearer is the EligibilityModule contract itself. It has no business showing up in user-facing role pickers.

Fix lives in `handleEligibilityModuleAdminHatSet`: when the admin hat is registered, strip it from `org.roleHatIds` and force `Role.isUserRole = false`. The hat itself stays in the Hats tree (still the real authority hat for the module), and `EligibilityModuleContract.eligibilityModuleAdminHat` still records its hatId — we just don't expose it as a user-facing role.

### Why this is safe

The admin-hat-set event fires once per org, at genesis. On a subgraph re-index from block 0, the handler runs at the right point during replay and cleans up already-deployed orgs. No contracts change needed.

For the in-between window before this PR ships *and* before a re-index, **poa-box/Poa-frontend#418** has a defensive filter in POContext that reads `eligibilityModuleAdminHat` and strips it client-side. Once this PR deploys, that filter becomes a no-op for new data.

## What changed

- `src/eligibility-module.ts` — extend `handleEligibilityModuleAdminHatSet` to remove the admin hat from `org.roleHatIds` and force `Role.isUserRole = false`. Idempotent.
- `tests/eligibility-module-utils.ts` — add `createEligibilityModuleAdminHatSetEvent` helper.
- `tests/eligibility-module.test.ts` — 3 new tests:
  - Removes admin hat from `roleHatIds` and flips `isUserRole`
  - Idempotent across replay
  - No-op when admin hat isn't in the list

## Related

- Companion frontend filter: poa-box/Poa-frontend#418
- Role-name extraction via viewHat (parallel PR): poa-box/subgraph-pop#181
- Long-term contract upgrade for event-driven metadata: poa-box/POP#168

## Test plan

- [x] `yarn codegen && yarn build` clean
- [x] `yarn test eligibility-module` — 17/17 pass (3 new)
- [x] Full suite `yarn test` — 258/258 pass
- [ ] After deploy: `Test6.organization.roleHatIds` no longer contains the admin hat ID; the team page tree renders 5 items instead of 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)