### PR TITLE
feat(task-manager): index EDIT_META + EDIT_FULL (v5)

### DIFF
--- a/pop-subgraph/abis/OrgDeployer.json
+++ b/pop-subgraph/abis/OrgDeployer.json
@@ -526,6 +526,23 @@
                 "internalType": "uint32"
               }
             ]
+          },
+          {
+            "name": "taskManagerPerms",
+            "type": "tuple",
+            "internalType": "struct OrgDeployer.TaskManagerPermConfig",
+            "components": [
+              {
+                "name": "roleIndices",
+                "type": "uint256[]",
+                "internalType": "uint256[]"
+              },
+              {
+                "name": "masks",
+                "type": "uint8[]",
+                "internalType": "uint8[]"
+              }
+            ]
           }
         ]
       }

--- a/pop-subgraph/abis/TaskManager.json
+++ b/pop-subgraph/abis/TaskManager.json
@@ -73,6 +73,24 @@
   },
   {
     "type": "function",
+    "name": "bootstrapGlobalPerms",
+    "inputs": [
+      {
+        "name": "hatIds",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "masks",
+        "type": "uint8[]",
+        "internalType": "uint8[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "bootstrapProjectsAndTasks",
     "inputs": [
       {
@@ -562,6 +580,24 @@
   },
   {
     "type": "function",
+    "name": "setFolders",
+    "inputs": [
+      {
+        "name": "expectedCurrentRoot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "newRoot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "setProjectRolePerm",
     "inputs": [
       {
@@ -634,6 +670,29 @@
         "name": "newBountyPayout",
         "type": "uint256",
         "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateTaskMetadata",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "newTitle",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "newMetadataHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
       }
     ],
     "outputs": [],
@@ -1233,6 +1292,22 @@
   },
   {
     "type": "error",
+    "name": "FoldersRootStale",
+    "inputs": [
+      {
+        "name": "expected",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "actual",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
     "name": "InvalidIndex",
     "inputs": []
   },
@@ -1289,6 +1364,11 @@
   {
     "type": "error",
     "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotOrganizer",
     "inputs": []
   },
   {

--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -188,13 +188,15 @@ type ProjectRolePermission @entity(immutable: false) {
   id: String! # taskManager-projectId-hatId (composite key)
   project: Project!
   hatId: BigInt!
-  mask: Int! # Permission bitmask (uint8: create=1, claim=2, review=4, assign=8, selfReview=16, budget=32)
+  mask: Int! # Permission bitmask (uint8: create=1, claim=2, review=4, assign=8, selfReview=16, budget=32, editMeta=64, editFull=128)
   canCreate: Boolean! # mask & 1
   canClaim: Boolean! # mask & 2
   canReview: Boolean! # mask & 4
   canAssign: Boolean! # mask & 8
   canSelfReview: Boolean! # mask & 16 — TaskPerm.SELF_REVIEW (review own submissions)
   canBudget: Boolean! # mask & 32 — TaskPerm.BUDGET (per-project override of global BUDGET grant)
+  canEditMeta: Boolean! # mask & 64 — TaskPerm.EDIT_META (edit title/metadataHash post-claim)
+  canEditFull: Boolean! # mask & 128 — TaskPerm.EDIT_FULL (edit payout+bounty+meta post-claim; strict superset of EDIT_META)
   setAt: BigInt!
   setAtBlock: BigInt!
   transactionHash: Bytes!
@@ -264,13 +266,15 @@ type GlobalRolePermission @entity(immutable: false) {
   id: String! # taskManager-hatId (composite key for cross-org isolation)
   taskManager: TaskManager!
   hatId: BigInt!
-  mask: Int! # uint8 (CREATE=1, CLAIM=2, REVIEW=4, ASSIGN=8, SELF_REVIEW=16, BUDGET=32)
+  mask: Int! # uint8 (CREATE=1, CLAIM=2, REVIEW=4, ASSIGN=8, SELF_REVIEW=16, BUDGET=32, EDIT_META=64, EDIT_FULL=128)
   canCreate: Boolean! # mask & 1
   canClaim: Boolean! # mask & 2
   canReview: Boolean! # mask & 4
   canAssign: Boolean! # mask & 8
   canSelfReview: Boolean! # mask & 16
   canBudget: Boolean! # mask & 32 — TaskPerm.BUDGET (resize project caps)
+  canEditMeta: Boolean! # mask & 64 — TaskPerm.EDIT_META (edit title/metadataHash post-claim)
+  canEditFull: Boolean! # mask & 128 — TaskPerm.EDIT_FULL (edit payout+bounty+meta post-claim; strict superset of EDIT_META)
   setAt: BigInt!
   setAtBlock: BigInt!
   transactionHash: Bytes!

--- a/pop-subgraph/src/task-manager.ts
+++ b/pop-subgraph/src/task-manager.ts
@@ -615,6 +615,8 @@ export function handleProjectRolePermSet(event: ProjectRolePermSet): void {
   perm.canAssign = (mask & 8) != 0;
   perm.canSelfReview = (mask & 16) != 0;
   perm.canBudget = (mask & 32) != 0;
+  perm.canEditMeta = (mask & 64) != 0;
+  perm.canEditFull = (mask & 128) != 0;
   perm.setAt = event.block.timestamp;
   perm.setAtBlock = event.block.number;
   perm.transactionHash = event.transaction.hash;
@@ -839,6 +841,8 @@ export function handleRolePermSet(event: RolePermSet): void {
   perm.canAssign = (mask & 8) != 0;
   perm.canSelfReview = (mask & 16) != 0;
   perm.canBudget = (mask & 32) != 0;
+  perm.canEditMeta = (mask & 64) != 0;
+  perm.canEditFull = (mask & 128) != 0;
   perm.setAt = event.block.timestamp;
   perm.setAtBlock = event.block.number;
   perm.transactionHash = event.transaction.hash;


### PR DESCRIPTION
## Summary
- Add `canEditMeta` (bit 64) and `canEditFull` (bit 128) discrete boolean fields to `ProjectRolePermission` and `GlobalRolePermission` so frontends can filter on them directly
- Re-sync TaskManager ABI to v5 (adds `updateTaskMetadata`, `bootstrapGlobalPerms`)
- Re-sync OrgDeployer ABI to v13 (adds `DeploymentParams.taskManagerPerms` field)
- No new event signatures — both bits ride the existing `RolePermSet` / `ProjectRolePermSet` events

## Context
TaskManager v5 (contracts PR landing soon) adds two new TaskPerm bits:
- `EDIT_META` (1 << 6 = 64) — edit only title + metadataHash on CLAIMED / SUBMITTED tasks
- `EDIT_FULL` (1 << 7 = 128) — edit everything (payout + bounty + meta); strict superset of EDIT_META

Pre-claim CREATE editing is unchanged. Terminal states (COMPLETED / CANCELLED) remain uneditable.

Granted via the existing entry points:
- `tm.setConfig(ROLE_PERM, abi.encode(hatId, mask))` for org-wide grants
- `tm.setProjectRolePerm(pid, hatId, mask)` for per-project grants
- `OrgDeployer.deployFullOrg(..., taskManagerPerms: { roleIndices[], masks[] })` at deploy time

All three paths emit the existing events the subgraph already handles.

## ⚠️ Deploy note: requires a full re-sync

Adding non-nullable fields (`canEditMeta: Boolean!`, `canEditFull: Boolean!`) to existing mutable entities means the deployed subgraph must **re-sync from genesis** when this version goes live. The mappings populate the new fields on every `RolePermSet` / `ProjectRolePermSet` event, so post-resync data will be correct — but the re-sync itself will take whatever a full historical reindex takes for the affected networks (Gnosis + Arbitrum).

The Graph hosted service / Studio handles this gracefully: the previous version keeps serving traffic until the new version finishes syncing, then a publish swap promotes it. Plan deploy timing accordingly.

Alternative if re-sync is too costly: make the new fields nullable (`Boolean`) and let pre-v5 entries return null. That avoids the resync but pushes the null-handling burden onto every frontend consumer. The non-null path is cleaner long-term; bringing this up so it's not a surprise.

## Test plan
- [x] `npm run codegen` — clean
- [x] `npm run build` — clean
- [ ] Deploy to staging studio, wait for re-sync, query `where: { canEditFull: true }` returns expected rows after a real EDIT_FULL grant lands on a live org (e.g. Test6 once the governance proposal passes)

## Companion PR
[poa-box/Poa-frontend#425](https://github.com/poa-box/Poa-frontend/pull/425) consumes these fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)