### PR TITLE
Revert admin hat subgraph fix + add viewHat role-name extraction + index v5 EDIT perms

### DIFF
--- a/pop-subgraph/abis/Hats.json
+++ b/pop-subgraph/abis/Hats.json
@@ -31,5 +31,25 @@
     ],
     "name": "HatStatusChanged",
     "type": "event"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_hatId", "type": "uint256" }
+    ],
+    "name": "viewHat",
+    "outputs": [
+      { "internalType": "string", "name": "details", "type": "string" },
+      { "internalType": "uint32", "name": "maxSupply", "type": "uint32" },
+      { "internalType": "uint32", "name": "supply", "type": "uint32" },
+      { "internalType": "address", "name": "eligibility", "type": "address" },
+      { "internalType": "address", "name": "toggle", "type": "address" },
+      { "internalType": "string", "name": "imageURI", "type": "string" },
+      { "internalType": "uint16", "name": "lastHatId", "type": "uint16" },
+      { "internalType": "uint8", "name": "level", "type": "uint8" },
+      { "internalType": "bool", "name": "active", "type": "bool" },
+      { "internalType": "bool", "name": "mutable_", "type": "bool" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/pop-subgraph/abis/OrgDeployer.json
+++ b/pop-subgraph/abis/OrgDeployer.json
@@ -526,6 +526,23 @@
                 "internalType": "uint32"
               }
             ]
+          },
+          {
+            "name": "taskManagerPerms",
+            "type": "tuple",
+            "internalType": "struct OrgDeployer.TaskManagerPermConfig",
+            "components": [
+              {
+                "name": "roleIndices",
+                "type": "uint256[]",
+                "internalType": "uint256[]"
+              },
+              {
+                "name": "masks",
+                "type": "uint8[]",
+                "internalType": "uint8[]"
+              }
+            ]
           }
         ]
       }

--- a/pop-subgraph/abis/TaskManager.json
+++ b/pop-subgraph/abis/TaskManager.json
@@ -73,6 +73,24 @@
   },
   {
     "type": "function",
+    "name": "bootstrapGlobalPerms",
+    "inputs": [
+      {
+        "name": "hatIds",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "masks",
+        "type": "uint8[]",
+        "internalType": "uint8[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "bootstrapProjectsAndTasks",
     "inputs": [
       {
@@ -562,6 +580,24 @@
   },
   {
     "type": "function",
+    "name": "setFolders",
+    "inputs": [
+      {
+        "name": "expectedCurrentRoot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "newRoot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
     "name": "setProjectRolePerm",
     "inputs": [
       {
@@ -634,6 +670,29 @@
         "name": "newBountyPayout",
         "type": "uint256",
         "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "updateTaskMetadata",
+    "inputs": [
+      {
+        "name": "id",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "newTitle",
+        "type": "bytes",
+        "internalType": "bytes"
+      },
+      {
+        "name": "newMetadataHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
       }
     ],
     "outputs": [],
@@ -1233,6 +1292,22 @@
   },
   {
     "type": "error",
+    "name": "FoldersRootStale",
+    "inputs": [
+      {
+        "name": "expected",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "actual",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ]
+  },
+  {
+    "type": "error",
     "name": "InvalidIndex",
     "inputs": []
   },
@@ -1289,6 +1364,11 @@
   {
     "type": "error",
     "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotOrganizer",
     "inputs": []
   },
   {

--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -188,13 +188,15 @@ type ProjectRolePermission @entity(immutable: false) {
   id: String! # taskManager-projectId-hatId (composite key)
   project: Project!
   hatId: BigInt!
-  mask: Int! # Permission bitmask (uint8: create=1, claim=2, review=4, assign=8, selfReview=16, budget=32)
+  mask: Int! # Permission bitmask (uint8: create=1, claim=2, review=4, assign=8, selfReview=16, budget=32, editMeta=64, editFull=128)
   canCreate: Boolean! # mask & 1
   canClaim: Boolean! # mask & 2
   canReview: Boolean! # mask & 4
   canAssign: Boolean! # mask & 8
   canSelfReview: Boolean! # mask & 16 — TaskPerm.SELF_REVIEW (review own submissions)
   canBudget: Boolean! # mask & 32 — TaskPerm.BUDGET (per-project override of global BUDGET grant)
+  canEditMeta: Boolean! # mask & 64 — TaskPerm.EDIT_META (edit title/metadataHash post-claim)
+  canEditFull: Boolean! # mask & 128 — TaskPerm.EDIT_FULL (edit payout+bounty+meta post-claim; strict superset of EDIT_META)
   setAt: BigInt!
   setAtBlock: BigInt!
   transactionHash: Bytes!
@@ -264,13 +266,15 @@ type GlobalRolePermission @entity(immutable: false) {
   id: String! # taskManager-hatId (composite key for cross-org isolation)
   taskManager: TaskManager!
   hatId: BigInt!
-  mask: Int! # uint8 (CREATE=1, CLAIM=2, REVIEW=4, ASSIGN=8, SELF_REVIEW=16, BUDGET=32)
+  mask: Int! # uint8 (CREATE=1, CLAIM=2, REVIEW=4, ASSIGN=8, SELF_REVIEW=16, BUDGET=32, EDIT_META=64, EDIT_FULL=128)
   canCreate: Boolean! # mask & 1
   canClaim: Boolean! # mask & 2
   canReview: Boolean! # mask & 4
   canAssign: Boolean! # mask & 8
   canSelfReview: Boolean! # mask & 16
   canBudget: Boolean! # mask & 32 — TaskPerm.BUDGET (resize project caps)
+  canEditMeta: Boolean! # mask & 64 — TaskPerm.EDIT_META (edit title/metadataHash post-claim)
+  canEditFull: Boolean! # mask & 128 — TaskPerm.EDIT_FULL (edit payout+bounty+meta post-claim; strict superset of EDIT_META)
   setAt: BigInt!
   setAtBlock: BigInt!
   transactionHash: Bytes!

--- a/pop-subgraph/src/eligibility-module.ts
+++ b/pop-subgraph/src/eligibility-module.ts
@@ -641,47 +641,8 @@ export function handleEligibilityModuleAdminHatSet(
     return;
   }
 
-  let adminHatId = event.params.hatId;
-  contract.eligibilityModuleAdminHat = adminHatId;
+  contract.eligibilityModuleAdminHat = event.params.hatId;
   contract.save();
-
-  // The admin hat is a system hat — its wearer is the EligibilityModule
-  // contract itself, not a user. It shouldn't appear in user-facing role
-  // pickers, the team-page role tree, or the leaderboard. Strip it from
-  // org.roleHatIds and force Role.isUserRole = false so every downstream
-  // consumer skips it cleanly.
-  //
-  // We do this on every admin-hat-set event (typically fires once, at
-  // genesis), so a subgraph re-index from block 0 correctly excludes the
-  // admin hat from already-deployed orgs — no contracts change needed.
-  let orgId = contract.organization;
-  let roleId = orgId.toHexString() + "-" + adminHatId.toString();
-  let role = Role.load(roleId);
-  if (role != null && role.isUserRole != false) {
-    role.isUserRole = false;
-    role.save();
-  }
-
-  let org = Organization.load(orgId);
-  if (org != null) {
-    let existing = org.roleHatIds;
-    if (existing != null && existing.length > 0) {
-      let filtered = new Array<BigInt>(0);
-      let removed = false;
-      for (let i = 0; i < existing.length; i++) {
-        if (existing[i].equals(adminHatId)) {
-          removed = true;
-        } else {
-          filtered.push(existing[i]);
-        }
-      }
-      if (removed) {
-        org.roleHatIds = filtered;
-        org.lastUpdatedAt = event.block.timestamp;
-        org.save();
-      }
-    }
-  }
 }
 
 export function handleGovernanceAdminSet(

--- a/pop-subgraph/src/eligibility-module.ts
+++ b/pop-subgraph/src/eligibility-module.ts
@@ -1,5 +1,6 @@
 import { Address, BigInt, Bytes, DataSourceContext, log } from "@graphprotocol/graph-ts";
 import { HatMetadata as HatMetadataTemplate } from "../generated/templates";
+import { Hats } from "../generated/Hats/Hats";
 import {
   EligibilityModuleInitialized as EligibilityModuleInitializedEvent,
   HatCreatedWithEligibility as HatCreatedWithEligibilityEvent,
@@ -159,6 +160,36 @@ export function handleHatCreatedWithEligibility(
   hat.createdAtBlock = event.block.number;
   hat.transactionHash = event.transaction.hash;
 
+  // Pull the role name + image off Hats Protocol. createHatWithEligibility
+  // passes the name/image as the `details`/`imageURI` args to Hats.createHat,
+  // but the EligibilityModule's HatCreatedWithEligibility event doesn't carry
+  // them — it only carries the new hatId and default flags. Without a read
+  // here, governance-created roles render as placeholder "Role N" in the
+  // frontend (the deployer wizard's roles get names from a separate
+  // RolesCreated event that createRole proposals don't emit).
+  //
+  // We use the EligibilityModule's stored hatsContract address rather than
+  // hardcoding it. If the contract call reverts (very unlikely — the hat was
+  // just created in the same tx), we leave name/image null and the frontend
+  // falls back to its existing "Role N" placeholder; the role still appears.
+  let roleName: string | null = null;
+  let roleImage: string | null = null;
+  if (eligibilityModule) {
+    let hatsContract = Hats.bind(Address.fromBytes(eligibilityModule.hatsContract));
+    let viewResult = hatsContract.try_viewHat(hatId);
+    if (!viewResult.reverted) {
+      let details = viewResult.value.getDetails();
+      let imageURI = viewResult.value.getImageURI();
+      if (details.length > 0) {
+        hat.name = details;
+        roleName = details;
+      }
+      if (imageURI.length > 0) {
+        roleImage = imageURI;
+      }
+    }
+  }
+
   hat.save();
 
   // Link Hat to Role entity + populate HatLookup.hat so HatStatusChanged
@@ -191,10 +222,25 @@ export function handleHatCreatedWithEligibility(
         org.lastUpdatedAt = event.block.timestamp;
         org.save();
       }
+      // Update Role.isUserRole + name/image. We always overwrite name/image
+      // when viewHat returned a non-empty value: createHatWithEligibility is
+      // the authoritative source for those fields at creation time, and we
+      // shouldn't keep stale nulls if a prior call (e.g. handler ordering)
+      // created the Role entity without them.
+      let roleChanged = false;
       if (role.isUserRole != true) {
         role.isUserRole = true;
-        role.save();
+        roleChanged = true;
       }
+      if (roleName !== null && role.name != roleName) {
+        role.name = roleName;
+        roleChanged = true;
+      }
+      if (roleImage !== null && role.image != roleImage) {
+        role.image = roleImage;
+        roleChanged = true;
+      }
+      if (roleChanged) role.save();
     }
   }
 }

--- a/pop-subgraph/src/task-manager.ts
+++ b/pop-subgraph/src/task-manager.ts
@@ -615,6 +615,8 @@ export function handleProjectRolePermSet(event: ProjectRolePermSet): void {
   perm.canAssign = (mask & 8) != 0;
   perm.canSelfReview = (mask & 16) != 0;
   perm.canBudget = (mask & 32) != 0;
+  perm.canEditMeta = (mask & 64) != 0;
+  perm.canEditFull = (mask & 128) != 0;
   perm.setAt = event.block.timestamp;
   perm.setAtBlock = event.block.number;
   perm.transactionHash = event.transaction.hash;
@@ -839,6 +841,8 @@ export function handleRolePermSet(event: RolePermSet): void {
   perm.canAssign = (mask & 8) != 0;
   perm.canSelfReview = (mask & 16) != 0;
   perm.canBudget = (mask & 32) != 0;
+  perm.canEditMeta = (mask & 64) != 0;
+  perm.canEditFull = (mask & 128) != 0;
   perm.setAt = event.block.timestamp;
   perm.setAtBlock = event.block.number;
   perm.transactionHash = event.transaction.hash;

--- a/pop-subgraph/tests/eligibility-module-utils.ts
+++ b/pop-subgraph/tests/eligibility-module-utils.ts
@@ -4,23 +4,9 @@ import {
   HatMetadataUpdated,
   HatCreatedWithEligibility,
   DefaultEligibilityUpdated,
-  EligibilityModuleAdminHatSet,
   RoleApplicationSubmitted,
   RoleApplicationWithdrawn
 } from "../generated/templates/EligibilityModule/EligibilityModule";
-
-export function createEligibilityModuleAdminHatSetEvent(
-  hatId: BigInt
-): EligibilityModuleAdminHatSet {
-  let event = changetype<EligibilityModuleAdminHatSet>(newMockEvent());
-
-  event.parameters = new Array();
-  event.parameters.push(
-    new ethereum.EventParam("hatId", ethereum.Value.fromUnsignedBigInt(hatId))
-  );
-
-  return event;
-}
 
 export function createHatMetadataUpdatedEvent(
   hatId: BigInt,

--- a/pop-subgraph/tests/eligibility-module.test.ts
+++ b/pop-subgraph/tests/eligibility-module.test.ts
@@ -3,9 +3,10 @@ import {
   describe,
   test,
   clearStore,
-  afterEach
+  afterEach,
+  createMockedFunction
 } from "matchstick-as/assembly/index";
-import { Address, Bytes, BigInt } from "@graphprotocol/graph-ts";
+import { Address, Bytes, BigInt, ethereum } from "@graphprotocol/graph-ts";
 
 /**
  * Helper function to convert bytes32 sha256 digest to IPFS CIDv0.
@@ -202,6 +203,39 @@ function setupEligibilityModuleEntities(): void {
   educationHub.save();
   paymentManager.save();
   organization.save();
+}
+
+/**
+ * Stub Hats.viewHat(hatId) at the given Hats contract address. The handler
+ * calls try_viewHat for every HatCreatedWithEligibility event to pull the
+ * role name + image off chain; matchstick fails the test if the call has no
+ * mock, so every test that exercises handleHatCreatedWithEligibility needs
+ * one. Pass empty strings to keep the default "no name extracted" behavior.
+ */
+function mockViewHat(
+  hatsAddress: Address,
+  hatId: BigInt,
+  details: string,
+  imageURI: string
+): void {
+  createMockedFunction(
+    hatsAddress,
+    "viewHat",
+    "viewHat(uint256):(string,uint32,uint32,address,address,string,uint16,uint8,bool,bool)"
+  )
+    .withArgs([ethereum.Value.fromUnsignedBigInt(hatId)])
+    .returns([
+      ethereum.Value.fromString(details),
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(1)),
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(0)),
+      ethereum.Value.fromAddress(Address.zero()),
+      ethereum.Value.fromAddress(Address.zero()),
+      ethereum.Value.fromString(imageURI),
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(0)),
+      ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(1)),
+      ethereum.Value.fromBoolean(true),
+      ethereum.Value.fromBoolean(true)
+    ]);
 }
 
 /**
@@ -476,6 +510,10 @@ describe("EligibilityModule - DefaultEligibilityUpdated", () => {
     let parentHatId = BigInt.fromI32(1000);
     let newHatId = BigInt.fromI32(3001);
 
+    // Setup defaults hatsContract to Address.zero(); empty viewHat result
+    // means the handler leaves name/image untouched.
+    mockViewHat(Address.zero(), newHatId, "", "");
+
     let event = createHatCreatedWithEligibilityEvent(
       creator,
       parentHatId,
@@ -516,6 +554,8 @@ describe("EligibilityModule - DefaultEligibilityUpdated", () => {
     let parentHatId = BigInt.fromI32(1000);
     let newHatId = BigInt.fromI32(3001);
 
+    mockViewHat(Address.zero(), newHatId, "", "");
+
     let event = createHatCreatedWithEligibilityEvent(
       creator, parentHatId, newHatId, true, true, BigInt.fromI32(0)
     );
@@ -529,6 +569,62 @@ describe("EligibilityModule - DefaultEligibilityUpdated", () => {
       "roleHatIds",
       "[1001, 1002, 3001]"
     );
+  });
+
+  test("HatCreatedWithEligibility populates Role.name + image from Hats.viewHat", () => {
+    setupEligibilityModuleEntities();
+
+    // Point the EligibilityModule at a known Hats contract address so the
+    // handler's Hats.bind(eligibilityModule.hatsContract) targets something
+    // we can mock. Setup defaults to Address.zero() which has no mock here.
+    let hatsAddr = Address.fromString("0x000000000000000000000000000000000000abcd");
+    let modAddr = Address.fromString("0xa16081f360e3847006db660bae1c6d1b2e17ec2a");
+    let mod = EligibilityModuleContract.load(modAddr);
+    if (mod) {
+      mod.hatsContract = hatsAddr;
+      mod.save();
+    }
+
+    let creator = Address.fromString("0x0000000000000000000000000000000000000099");
+    let parentHatId = BigInt.fromI32(1000);
+    let newHatId = BigInt.fromI32(3002);
+
+    // Mock Hats.viewHat(3002) → (details="Treasurer", maxSupply=5, supply=0,
+    // eligibility=mod, toggle=0, imageURI="ipfs://logo", lastHatId=0, level=4,
+    // active=true, mutable=true).
+    createMockedFunction(
+      hatsAddr,
+      "viewHat",
+      "viewHat(uint256):(string,uint32,uint32,address,address,string,uint16,uint8,bool,bool)"
+    )
+      .withArgs([ethereum.Value.fromUnsignedBigInt(newHatId)])
+      .returns([
+        ethereum.Value.fromString("Treasurer"),
+        ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(5)),
+        ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(0)),
+        ethereum.Value.fromAddress(modAddr),
+        ethereum.Value.fromAddress(Address.zero()),
+        ethereum.Value.fromString("ipfs://logo"),
+        ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(0)),
+        ethereum.Value.fromUnsignedBigInt(BigInt.fromI32(4)),
+        ethereum.Value.fromBoolean(true),
+        ethereum.Value.fromBoolean(true)
+      ]);
+
+    let event = createHatCreatedWithEligibilityEvent(
+      creator, parentHatId, newHatId, true, true, BigInt.fromI32(0)
+    );
+    handleHatCreatedWithEligibility(event);
+
+    let orgId = Bytes.fromHexString("0x1111111111111111111111111111111111111111111111111111111111111111");
+    let roleId = orgId.toHexString() + "-" + newHatId.toString();
+    let hatEntityId = "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-3002";
+
+    // Name should be picked up on both Hat and Role.
+    assert.fieldEquals("Hat", hatEntityId, "name", "Treasurer");
+    assert.fieldEquals("Role", roleId, "name", "Treasurer");
+    assert.fieldEquals("Role", roleId, "image", "ipfs://logo");
+    assert.fieldEquals("Role", roleId, "isUserRole", "true");
   });
 });
 

--- a/pop-subgraph/tests/eligibility-module.test.ts
+++ b/pop-subgraph/tests/eligibility-module.test.ts
@@ -26,7 +26,6 @@ import {
   handleHatMetadataUpdated,
   handleHatCreatedWithEligibility,
   handleDefaultEligibilityUpdated,
-  handleEligibilityModuleAdminHatSet,
   handleRoleApplicationSubmitted,
   handleRoleApplicationWithdrawn
 } from "../src/eligibility-module";
@@ -34,7 +33,6 @@ import {
   createHatMetadataUpdatedEvent,
   createHatCreatedWithEligibilityEvent,
   createDefaultEligibilityUpdatedEvent,
-  createEligibilityModuleAdminHatSetEvent,
   createRoleApplicationSubmittedEvent,
   createRoleApplicationWithdrawnEvent
 } from "./eligibility-module-utils";
@@ -530,111 +528,6 @@ describe("EligibilityModule - DefaultEligibilityUpdated", () => {
       orgId.toHexString(),
       "roleHatIds",
       "[1001, 1002, 3001]"
-    );
-  });
-});
-
-describe("EligibilityModule - EligibilityModuleAdminHatSet", () => {
-  afterEach(() => {
-    clearStore();
-  });
-
-  test("Removes admin hat from org.roleHatIds and forces Role.isUserRole = false", () => {
-    setupEligibilityModuleEntities();
-
-    // Simulate the post-PR-#180 state where the admin hat snuck into the
-    // org's role list (this is what Test6 currently looks like — see issue).
-    let orgId = Bytes.fromHexString(
-      "0x1111111111111111111111111111111111111111111111111111111111111111"
-    );
-    let adminHatId = BigInt.fromI32(2500);
-    let org = Organization.load(orgId);
-    if (org) {
-      org.roleHatIds = [BigInt.fromI32(1001), BigInt.fromI32(1002), adminHatId];
-      org.save();
-    }
-
-    // Seed a Role entity for the admin hat with isUserRole=true to mirror
-    // the bad state on Test6. The handler should flip it back to false.
-    let roleId = orgId.toHexString() + "-" + adminHatId.toString();
-    let role = new Role(roleId);
-    role.organization = orgId;
-    role.hatId = adminHatId;
-    role.isUserRole = true;
-    role.createdAt = BigInt.fromI32(1000);
-    role.createdAtBlock = BigInt.fromI32(100);
-    role.transactionHash = Bytes.fromHexString("0xabcd");
-    role.save();
-
-    let event = createEligibilityModuleAdminHatSetEvent(adminHatId);
-    handleEligibilityModuleAdminHatSet(event);
-
-    // Admin hat is stripped from the user-facing role list.
-    assert.fieldEquals(
-      "Organization",
-      orgId.toHexString(),
-      "roleHatIds",
-      "[1001, 1002]"
-    );
-    // And its Role is no longer flagged as user-facing.
-    assert.fieldEquals("Role", roleId, "isUserRole", "false");
-    // The contract entity records the admin hat (for callers that need it).
-    assert.fieldEquals(
-      "EligibilityModuleContract",
-      "0xa16081f360e3847006db660bae1c6d1b2e17ec2a",
-      "eligibilityModuleAdminHat",
-      "2500"
-    );
-  });
-
-  test("Idempotent — running twice leaves state stable", () => {
-    setupEligibilityModuleEntities();
-    let orgId = Bytes.fromHexString(
-      "0x1111111111111111111111111111111111111111111111111111111111111111"
-    );
-    let adminHatId = BigInt.fromI32(2500);
-    let org = Organization.load(orgId);
-    if (org) {
-      org.roleHatIds = [BigInt.fromI32(1001), BigInt.fromI32(1002), adminHatId];
-      org.save();
-    }
-
-    let event = createEligibilityModuleAdminHatSetEvent(adminHatId);
-    handleEligibilityModuleAdminHatSet(event);
-    handleEligibilityModuleAdminHatSet(event);
-
-    assert.fieldEquals(
-      "Organization",
-      orgId.toHexString(),
-      "roleHatIds",
-      "[1001, 1002]"
-    );
-  });
-
-  test("No-op when admin hat isn't in roleHatIds and no Role exists", () => {
-    setupEligibilityModuleEntities();
-    let orgId = Bytes.fromHexString(
-      "0x1111111111111111111111111111111111111111111111111111111111111111"
-    );
-    let adminHatId = BigInt.fromI32(9999);
-    // roleHatIds stays as the setup default [1001, 1002] — admin hat is
-    // not in there, no Role exists for it. The handler should still
-    // record the admin hat on the contract entity without touching org.
-
-    let event = createEligibilityModuleAdminHatSetEvent(adminHatId);
-    handleEligibilityModuleAdminHatSet(event);
-
-    assert.fieldEquals(
-      "Organization",
-      orgId.toHexString(),
-      "roleHatIds",
-      "[1001, 1002]"
-    );
-    assert.fieldEquals(
-      "EligibilityModuleContract",
-      "0xa16081f360e3847006db660bae1c6d1b2e17ec2a",
-      "eligibilityModuleAdminHat",
-      "9999"
     );
   });
 });


### PR DESCRIPTION
Three things bundled into one PR per request:

1. **Revert #182** — admin hat filtering moves back out of the subgraph (it stays in `org.roleHatIds` as canonical source of truth). The frontend filter in [poa-box/Poa-frontend#418](https://github.com/poa-box/Poa-frontend/pull/418) handles hiding it from user-facing UI.
2. **viewHat role-name extraction (was #181)** — `handleHatCreatedWithEligibility` binds Hats Protocol via `EligibilityModuleContract.hatsContract` and calls `try_viewHat(newHatId)` to pull `details` → `Hat.name` + `Role.name` and `imageURI` → `Role.image`. Fixes the "Role 4/5/6" placeholder labels on Test6.
3. **v5 EDIT_META + EDIT_FULL perms (was #183)** — adds `canEditMeta` (bit 64) + `canEditFull` (bit 128) discrete boolean fields on `ProjectRolePermission` and `GlobalRolePermission`. Re-syncs TaskManager ABI to v5 and OrgDeployer ABI to v13.

## Commits

| Commit | What |
|---|---|
| `1aab825` | Revert `#182` |
| `8ee60c2` | viewHat role-name extraction (previously `#181`) |
| `6a9c106` | v5 EDIT perms (previously `#183`) |

## ⚠️ Deploy note: requires a full re-sync

The v5 perms commit adds non-nullable fields (`canEditMeta: Boolean!`, `canEditFull: Boolean!`) to existing mutable entities. Deployed subgraph must re-sync from genesis when this version goes live. Mappings populate the new fields on every `RolePermSet` / `ProjectRolePermSet` event so post-resync data will be correct.

The Graph hosted service / Studio handles this gracefully — previous version keeps serving traffic until the new version finishes syncing, then a publish swap promotes it.

## Test plan

- [x] `yarn codegen && yarn build` — clean
- [x] `yarn test` — 256/256 pass
- [ ] After deploy + re-sync: `Test6.organization.roles` returns `name: "Treasurer"` etc. (proves viewHat extraction)
- [ ] After deploy + re-sync: `Test6.organization.roleHatIds` still contains admin hat (proves revert) — frontend (#418) hides it from UI via POContext filter
- [ ] Once TaskManager v5 lands and a real EDIT_FULL grant happens on a live org: `where: { canEditFull: true }` returns expected rows

## Related

- Frontend createRole + admin-hat filter: poa-box/Poa-frontend#418
- v5 EDIT perms frontend consumer: poa-box/Poa-frontend#425
- Long-term contract upgrade for event-driven role metadata: poa-box/POP#168
- Race-condition contracts fix: poa-box/POP#166

This PR supersedes #181 and #183 — closing those once this is reviewed.