### PR TITLE
fix(eligibility-module): declare Hats ABI in template so handlers can bind it

### DIFF
--- a/pop-subgraph/subgraph.yaml
+++ b/pop-subgraph/subgraph.yaml
@@ -513,6 +513,8 @@ templates:
       abis:
         - name: EligibilityModule
           file: ./abis/EligibilityModule.json
+        - name: Hats
+          file: ./abis/Hats.json
       eventHandlers:
         - event: EligibilityModuleInitialized(indexed address,indexed address)
           handler: handleEligibilityModuleInitialized


### PR DESCRIPTION
## What broke

After #184 deployed, indexing crashed on Gnosis at block #45424229 with:

\`\`\`
Could not find ABI for contract \"Hats\", try adding it to the 'abis' section
of the subgraph manifest in handler \`handleHatCreatedWithEligibility\`
\`\`\`

## Why

\`handleHatCreatedWithEligibility\` calls \`Hats.bind(eligibilityModule.hatsContract).try_viewHat(hatId)\` to pull \`details\` + \`imageURI\` for role name extraction. The generated AssemblyScript binding (\`generated/Hats/Hats.ts\`) was fine, but the wasm runtime needs the manifest to declare the Hats ABI under the relevant data source's \`abis:\` list so it can encode the contract call at runtime. #184 added \`abis/Hats.json\` to disk but never wired it into \`subgraph.yaml\`.

Matchstick tests were happy with the unwired ABI because mocked function calls bypass the manifest ABI lookup — so this was a runtime-only failure that didn't show up in CI.

## The fix

Add \`- name: Hats / file: ./abis/Hats.json\` to the EligibilityModule template's \`abis:\` block in \`subgraph.yaml\`. One-line change.

## Test plan

- [x] \`yarn codegen && yarn build\` clean
- [x] \`yarn test eligibility-module\` — 15/15 pass
- [ ] After deploy, re-indexing past block #45424229 succeeds (no more \"Could not find ABI for contract Hats\")
- [ ] Test6 roles 4/5/6 render with real names (\"Treasurer\", \"Newcomer\", \"TaskRunner\") once the new subgraph version finishes syncing

## Related

- Companion frontend createRole + admin-hat filter: poa-box/Poa-frontend#418
- Long-term contract upgrade for event-driven role metadata: poa-box/POP#168