### PR TITLE
fix(voting): index creator/voting hats seeded at deploy time

### DIFF
--- a/pop-subgraph/src/direct-democracy-voting.ts
+++ b/pop-subgraph/src/direct-democracy-voting.ts
@@ -1,5 +1,6 @@
 import { Address, Bytes, BigInt, DataSourceContext } from "@graphprotocol/graph-ts";
 import {
+  DirectDemocracyVoting as DirectDemocracyVotingAbi,
   Initialized,
   ExecutorUpdated,
   ThresholdPctSet,
@@ -26,7 +27,7 @@ import {
   ProposalMetadata
 } from "../generated/schema";
 import { ProposalMetadata as ProposalMetadataTemplate } from "../generated/templates";
-import { getUsernameForAddress, loadExistingUser, createExecutorChange, getOrCreateRole } from "./utils";
+import { getUsernameForAddress, loadExistingUser, createExecutorChange, getOrCreateRole, backfillVotingHatPermissions } from "./utils";
 
 // Zero hash constant for comparison
 const ZERO_HASH = Bytes.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000000");
@@ -78,7 +79,8 @@ function createProposalMetadataDataSource(descriptionHash: Bytes, proposalEntity
 
 /**
  * Handler for Initialized event
- * Updates the DirectDemocracyVotingContract entity with initialization data.
+ * Updates the DirectDemocracyVotingContract entity with initialization data and
+ * backfills the creator/voting-hat permissions seeded during initialize().
  * The entity should already exist, created by handleOrgDeployed.
  */
 export function handleInitialized(event: Initialized): void {
@@ -90,7 +92,38 @@ export function handleInitialized(event: Initialized): void {
     return;
   }
 
-  // Update initialization data
+  // Both creator and voting hats are seeded inside initialize() WITHOUT
+  // emitting per-hat events (HatSet/CreatorHatSet only fire for post-deploy
+  // changes), so the event handlers miss deploy-time grants. Read the
+  // authoritative on-chain enumerations now (initialize() has run) and
+  // backfill, so roles that can create polls or vote in polls appear in the
+  // permissions matrix.
+  let bound = DirectDemocracyVotingAbi.bind(event.address);
+
+  let creatorHats = bound.try_creatorHats();
+  if (!creatorHats.reverted) {
+    backfillVotingHatPermissions(
+      event.address,
+      "DirectDemocracyVoting",
+      contract.organization,
+      creatorHats.value,
+      "Creator",
+      event
+    );
+  }
+
+  let votingHats = bound.try_votingHats();
+  if (!votingHats.reverted) {
+    backfillVotingHatPermissions(
+      event.address,
+      "DirectDemocracyVoting",
+      contract.organization,
+      votingHats.value,
+      "Voter",
+      event
+    );
+  }
+
   // Note: executor, quorum, hats will be set by their respective events
   contract.save();
 }

--- a/pop-subgraph/src/hybrid-voting.ts
+++ b/pop-subgraph/src/hybrid-voting.ts
@@ -1,5 +1,6 @@
 import { Address, Bytes, BigInt, DataSourceContext } from "@graphprotocol/graph-ts";
 import {
+  HybridVoting as HybridVotingAbi,
   Initialized,
   ExecutorUpdated,
   ThresholdPctSet,
@@ -26,7 +27,7 @@ import {
   ProposalMetadata
 } from "../generated/schema";
 import { ProposalMetadata as ProposalMetadataTemplate } from "../generated/templates";
-import { getUsernameForAddress, loadExistingUser, createHatPermission, createExecutorChange, getOrCreateRole } from "./utils";
+import { getUsernameForAddress, loadExistingUser, createHatPermission, createExecutorChange, getOrCreateRole, backfillVotingHatPermissions } from "./utils";
 
 // Zero hash constant for comparison
 const ZERO_HASH = Bytes.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000000");
@@ -78,7 +79,8 @@ function createProposalMetadataDataSource(descriptionHash: Bytes, proposalEntity
 
 /**
  * Handler for Initialized event
- * Updates the HybridVotingContract entity with initialization data.
+ * Updates the HybridVotingContract entity with initialization data and
+ * backfills the creator-hat permissions seeded during initialize().
  * The entity should already exist, created by handleOrgDeployed.
  */
 export function handleInitialized(event: Initialized): void {
@@ -90,7 +92,25 @@ export function handleInitialized(event: Initialized): void {
     return;
   }
 
-  // Update initialization data
+  // Creator hats are seeded inside initialize() WITHOUT emitting HatSet, so
+  // handleHatSet never sees deploy-time grants — a role that can create
+  // proposals would otherwise be missing from the permissions matrix. Read the
+  // authoritative on-chain set now (initialize() has run by this point) and
+  // backfill. HV voters are class-based (see handleClassesReplaced), so there
+  // is no voting-hat array to read here.
+  let bound = HybridVotingAbi.bind(event.address);
+  let creatorHats = bound.try_creatorHats();
+  if (!creatorHats.reverted) {
+    backfillVotingHatPermissions(
+      event.address,
+      "HybridVoting",
+      contract.organization,
+      creatorHats.value,
+      "Creator",
+      event
+    );
+  }
+
   // Note: executor, quorum, hats will be set by their respective events
   contract.save();
 }

--- a/pop-subgraph/src/utils.ts
+++ b/pop-subgraph/src/utils.ts
@@ -180,6 +180,66 @@ export function createHatPermission(
 }
 
 /**
+ * Backfill HatPermission rows for hats read directly from a voting contract's
+ * on-chain enumeration — HybridVoting.creatorHats() and
+ * DirectDemocracyVoting.creatorHats()/votingHats().
+ *
+ * Why this is needed: both voting contracts seed these arrays inside
+ * initialize() via HatManager.setHatInArray WITHOUT emitting a per-hat
+ * HatSet/CreatorHatSet event — only the post-deploy setters emit. The
+ * event-driven handlers therefore never see grants made AT DEPLOYMENT, so a
+ * role that can create proposals/polls (or vote in polls) was rendered as "—"
+ * in the org permissions matrix. Reading the authoritative on-chain set once,
+ * at Initialized (after initialize() has run), closes that gap for both
+ * already-deployed and future orgs.
+ *
+ * Idempotent with the event handlers by design: identical `address-hatId-role`
+ * id scheme. If a row already exists we leave it untouched — an event carries
+ * the authoritative `allowed` flag and a precise timestamp, and a deploy-time
+ * read could only overwrite it with staler data. Conversely, any later
+ * grant/revoke flows through handleHatSet / handleCreatorHatSet and overrides
+ * what we seed here. hatType is intentionally left null: the array getters do
+ * not carry it and no consumer keys off it (the matrix uses contractType +
+ * permissionRole + allowed).
+ */
+export function backfillVotingHatPermissions(
+  contractAddress: Address,
+  contractType: string,
+  orgId: Bytes,
+  hatIds: Array<BigInt>,
+  permissionRole: string,
+  event: ethereum.Event
+): void {
+  for (let i = 0; i < hatIds.length; i++) {
+    let hatId = hatIds[i];
+    let id =
+      contractAddress.toHexString() + "-" + hatId.toString() + "-" + permissionRole;
+
+    // An event handler already recorded this grant authoritatively — keep it.
+    if (HatPermission.load(id) != null) {
+      continue;
+    }
+
+    let permission = new HatPermission(id);
+    permission.contractAddress = contractAddress;
+    permission.contractType = contractType;
+    permission.organization = orgId;
+    permission.hatId = hatId;
+    permission.permissionRole = permissionRole;
+
+    // Link to the Role entity (seeded from roleHatIds at OrgDeployed).
+    let role = getOrCreateRole(orgId, hatId, event);
+    permission.role = role.id;
+
+    permission.allowed = true; // membership in the on-chain array == allowed
+    permission.setAt = event.block.timestamp;
+    permission.setAtBlock = event.block.number;
+    permission.transactionHash = event.transaction.hash;
+    permission.save();
+  }
+}
+
+/**
  * Create a consolidated ExecutorChange entity
  * Used by: DirectDemocracyVoting, QuickJoin, EducationHub
  */

--- a/pop-subgraph/tests/direct-democracy-voting-utils.ts
+++ b/pop-subgraph/tests/direct-democracy-voting-utils.ts
@@ -1,0 +1,31 @@
+import { newMockEvent } from "matchstick-as/assembly/index";
+import { ethereum, BigInt } from "@graphprotocol/graph-ts";
+import {
+  Initialized,
+  CreatorHatSet
+} from "../generated/templates/DirectDemocracyVoting/DirectDemocracyVoting";
+
+export function createInitializedEvent(version: BigInt): Initialized {
+  let event = changetype<Initialized>(newMockEvent());
+
+  event.parameters = new Array();
+  event.parameters.push(
+    new ethereum.EventParam("version", ethereum.Value.fromUnsignedBigInt(version))
+  );
+
+  return event;
+}
+
+export function createCreatorHatSetEvent(hat: BigInt, allowed: boolean): CreatorHatSet {
+  let event = changetype<CreatorHatSet>(newMockEvent());
+
+  event.parameters = new Array();
+  event.parameters.push(
+    new ethereum.EventParam("hat", ethereum.Value.fromUnsignedBigInt(hat))
+  );
+  event.parameters.push(
+    new ethereum.EventParam("allowed", ethereum.Value.fromBoolean(allowed))
+  );
+
+  return event;
+}

--- a/pop-subgraph/tests/direct-democracy-voting.test.ts
+++ b/pop-subgraph/tests/direct-democracy-voting.test.ts
@@ -1,0 +1,158 @@
+import {
+  assert,
+  describe,
+  test,
+  clearStore,
+  afterEach,
+  createMockedFunction
+} from "matchstick-as/assembly/index";
+import { Address, BigInt, Bytes, ethereum } from "@graphprotocol/graph-ts";
+import {
+  handleInitialized,
+  handleCreatorHatSet
+} from "../src/direct-democracy-voting";
+import {
+  createInitializedEvent,
+  createCreatorHatSetEvent
+} from "./direct-democracy-voting-utils";
+import {
+  Organization,
+  DirectDemocracyVotingContract
+} from "../generated/schema";
+
+/**
+ * Minimal setup: handleInitialized only needs the Organization (for the org
+ * link + roleHatIds) and the DirectDemocracyVotingContract entity that
+ * handleOrgDeployed would have created. Organization's contract links are
+ * nullable in the schema, so no sibling contracts are required.
+ */
+function setupDDVContract(contractAddress: Address): void {
+  let orgId = Bytes.fromHexString(
+    "0x2222222222222222222222222222222222222222222222222222222222222222"
+  );
+  let organization = new Organization(orgId);
+  organization.roleHatIds = [BigInt.fromI32(1001), BigInt.fromI32(1002)];
+  organization.directDemocracyVoting = contractAddress;
+  organization.save();
+
+  let ddv = new DirectDemocracyVotingContract(contractAddress);
+  ddv.organization = orgId;
+  ddv.executor = Address.zero();
+  ddv.thresholdPct = 0;
+  ddv.quorum = 0;
+  ddv.hats = Address.zero();
+  ddv.createdAt = BigInt.fromI32(1000);
+  ddv.createdAtBlock = BigInt.fromI32(100);
+  ddv.save();
+}
+
+/**
+ * Mock a uint256[] getter (creatorHats() / votingHats()) — the on-chain
+ * enumerations handleInitialized reads to backfill hats that initialize()
+ * seeded without events.
+ */
+function mockHatArray(contractAddress: Address, fnName: string, hatIds: BigInt[]): void {
+  createMockedFunction(
+    contractAddress,
+    fnName,
+    fnName + "():(uint256[])"
+  ).returns([ethereum.Value.fromUnsignedBigIntArray(hatIds)]);
+}
+
+describe("DirectDemocracyVoting", () => {
+  afterEach(() => {
+    clearStore();
+  });
+
+  describe("Initialized backfill", () => {
+    test("Creator and voting hats backfilled from on-chain enumerations", () => {
+      let event = createInitializedEvent(BigInt.fromI32(1));
+      setupDDVContract(event.address);
+      mockHatArray(event.address, "creatorHats", [BigInt.fromI32(1002)]);
+      mockHatArray(event.address, "votingHats", [
+        BigInt.fromI32(1001),
+        BigInt.fromI32(1002)
+      ]);
+
+      handleInitialized(event);
+
+      // 1 creator + 2 voter rows
+      assert.entityCount("HatPermission", 3);
+
+      let creator = event.address.toHexString() + "-1002-Creator";
+      assert.fieldEquals("HatPermission", creator, "permissionRole", "Creator");
+      assert.fieldEquals("HatPermission", creator, "contractType", "DirectDemocracyVoting");
+      assert.fieldEquals("HatPermission", creator, "allowed", "true");
+
+      let voter1 = event.address.toHexString() + "-1001-Voter";
+      assert.fieldEquals("HatPermission", voter1, "permissionRole", "Voter");
+      assert.fieldEquals("HatPermission", voter1, "allowed", "true");
+
+      let voter2 = event.address.toHexString() + "-1002-Voter";
+      assert.fieldEquals("HatPermission", voter2, "permissionRole", "Voter");
+    });
+
+    test("Same hat can hold both Creator and Voter rows", () => {
+      let event = createInitializedEvent(BigInt.fromI32(1));
+      setupDDVContract(event.address);
+      mockHatArray(event.address, "creatorHats", [BigInt.fromI32(1002)]);
+      mockHatArray(event.address, "votingHats", [BigInt.fromI32(1002)]);
+
+      handleInitialized(event);
+
+      assert.entityCount("HatPermission", 2);
+      assert.fieldEquals(
+        "HatPermission",
+        event.address.toHexString() + "-1002-Creator",
+        "allowed",
+        "true"
+      );
+      assert.fieldEquals(
+        "HatPermission",
+        event.address.toHexString() + "-1002-Voter",
+        "allowed",
+        "true"
+      );
+    });
+
+    test("Backfill leaves an event-sourced creator row untouched", () => {
+      let event = createInitializedEvent(BigInt.fromI32(1));
+      setupDDVContract(event.address);
+
+      // CreatorHatSet arrives first (post-deploy grant)...
+      handleCreatorHatSet(createCreatorHatSetEvent(BigInt.fromI32(1002), true));
+      // ...then the backfill reads the same hat — must not duplicate or overwrite.
+      mockHatArray(event.address, "creatorHats", [BigInt.fromI32(1002)]);
+      mockHatArray(event.address, "votingHats", []);
+      handleInitialized(event);
+
+      assert.entityCount("HatPermission", 1);
+      assert.fieldEquals(
+        "HatPermission",
+        event.address.toHexString() + "-1002-Creator",
+        "allowed",
+        "true"
+      );
+    });
+
+    test("Reverting getters are tolerated — no crash, no permissions", () => {
+      let event = createInitializedEvent(BigInt.fromI32(1));
+      setupDDVContract(event.address);
+      createMockedFunction(
+        event.address,
+        "creatorHats",
+        "creatorHats():(uint256[])"
+      ).reverts();
+      createMockedFunction(
+        event.address,
+        "votingHats",
+        "votingHats():(uint256[])"
+      ).reverts();
+
+      handleInitialized(event);
+
+      assert.entityCount("DirectDemocracyVotingContract", 1);
+      assert.entityCount("HatPermission", 0);
+    });
+  });
+});

--- a/pop-subgraph/tests/hybrid-voting.test.ts
+++ b/pop-subgraph/tests/hybrid-voting.test.ts
@@ -3,9 +3,10 @@ import {
   describe,
   test,
   clearStore,
-  afterEach
+  afterEach,
+  createMockedFunction
 } from "matchstick-as/assembly/index";
-import { Address, BigInt, Bytes } from "@graphprotocol/graph-ts";
+import { Address, BigInt, Bytes, ethereum } from "@graphprotocol/graph-ts";
 import {
   handleInitialized,
   handleExecutorUpdated,
@@ -186,6 +187,18 @@ function setupHybridVotingContract(contractAddress: Address): void {
   organization.save();
 }
 
+/**
+ * Mock HybridVoting.creatorHats() — the on-chain enumeration handleInitialized
+ * reads to backfill creator hats that initialize() seeded without events.
+ */
+function mockCreatorHats(contractAddress: Address, hatIds: BigInt[]): void {
+  createMockedFunction(
+    contractAddress,
+    "creatorHats",
+    "creatorHats():(uint256[])"
+  ).returns([ethereum.Value.fromUnsignedBigIntArray(hatIds)]);
+}
+
 describe("HybridVoting", () => {
   afterEach(() => {
     clearStore();
@@ -198,10 +211,14 @@ describe("HybridVoting", () => {
 
       // Setup contract first (simulating OrgDeployed)
       setupHybridVotingContract(event.address);
+      // initialize() seeds creator hats with no event; handler reads them on-chain.
+      mockCreatorHats(event.address, []);
 
       handleInitialized(event);
 
       assert.entityCount("HybridVotingContract", 1);
+      // No creator hats configured → no permissions backfilled.
+      assert.entityCount("HatPermission", 0);
 
       // Verify contract still exists with default values
       let contractId = event.address.toHexString();
@@ -213,6 +230,74 @@ describe("HybridVoting", () => {
       );
       assert.fieldEquals("HybridVotingContract", contractId, "thresholdPct", "0");
       assert.fieldEquals("HybridVotingContract", contractId, "quorum", "0");
+    });
+
+    test("Creator-hat permissions backfilled from on-chain creatorHats()", () => {
+      let event = createInitializedEvent(BigInt.fromI32(1));
+      setupHybridVotingContract(event.address);
+      // Two deploy-time creator hats that never emitted a HatSet event.
+      mockCreatorHats(event.address, [BigInt.fromI32(1001), BigInt.fromI32(1002)]);
+
+      handleInitialized(event);
+
+      assert.entityCount("HatPermission", 2);
+
+      let p1 = event.address.toHexString() + "-1001-Creator";
+      assert.fieldEquals("HatPermission", p1, "permissionRole", "Creator");
+      assert.fieldEquals("HatPermission", p1, "contractType", "HybridVoting");
+      assert.fieldEquals("HatPermission", p1, "allowed", "true");
+      assert.fieldEquals("HatPermission", p1, "hatId", "1001");
+
+      let p2 = event.address.toHexString() + "-1002-Creator";
+      assert.fieldEquals("HatPermission", p2, "allowed", "true");
+    });
+
+    test("Backfill is idempotent — a later HatSet overrides in place", () => {
+      let event = createInitializedEvent(BigInt.fromI32(1));
+      setupHybridVotingContract(event.address);
+      mockCreatorHats(event.address, [BigInt.fromI32(1001)]);
+
+      // Deploy-time backfill grants the creator hat...
+      handleInitialized(event);
+      let pid = event.address.toHexString() + "-1001-Creator";
+      assert.fieldEquals("HatPermission", pid, "allowed", "true");
+
+      // ...then governance revokes it post-deploy via setCreatorHatAllowed.
+      handleHatSet(createHatSetEvent(0, BigInt.fromI32(1001), false));
+
+      assert.entityCount("HatPermission", 1); // updated in place, not duplicated
+      assert.fieldEquals("HatPermission", pid, "allowed", "false");
+    });
+
+    test("An event-sourced permission is not clobbered by the backfill", () => {
+      let event = createInitializedEvent(BigInt.fromI32(1));
+      setupHybridVotingContract(event.address);
+
+      // Event arrives first (e.g. a post-deploy grant), recording hatType 0.
+      handleHatSet(createHatSetEvent(0, BigInt.fromI32(1001), true));
+      // Backfill then sees the same hat on-chain — must leave the row untouched.
+      mockCreatorHats(event.address, [BigInt.fromI32(1001)]);
+      handleInitialized(event);
+
+      assert.entityCount("HatPermission", 1);
+      let pid = event.address.toHexString() + "-1001-Creator";
+      assert.fieldEquals("HatPermission", pid, "allowed", "true");
+      assert.fieldEquals("HatPermission", pid, "hatType", "0"); // preserved from event
+    });
+
+    test("Reverting creatorHats() is tolerated — no crash, no permissions", () => {
+      let event = createInitializedEvent(BigInt.fromI32(1));
+      setupHybridVotingContract(event.address);
+      createMockedFunction(
+        event.address,
+        "creatorHats",
+        "creatorHats():(uint256[])"
+      ).reverts();
+
+      handleInitialized(event);
+
+      assert.entityCount("HybridVotingContract", 1);
+      assert.entityCount("HatPermission", 0);
     });
   });
 


### PR DESCRIPTION
## Problem

The org permissions matrix on `/team` under-reports who can create **proposals** (HybridVoting) and **polls** (DirectDemocracyVoting) — a role that can create proposals on-chain shows "—".

Observed on **Decentral Park** (Gnosis, `0x3721…7d78`):
- On-chain `HybridVoting.creatorHats()` → **[Neighbor, Delegate, Agent]**
- Subgraph `hatPermissions` (HybridVoting/Creator) → **Agent only**
- `DirectDemocracyVoting.creatorHats()` → **[Neighbor, Delegate]**, but the subgraph had **no** DDV Creator rows, so the matrix had no "Poll Create" column at all.

So Delegates appear unable to create proposals/polls even though they can on-chain.

## Root cause

Both voting contracts seed their hat arrays inside `initialize()` via `HatManager.setHatInArray` **without emitting** `HatSet`/`CreatorHatSet`. Only the post-deploy setters (`setCreatorHatAllowed`, `setConfig(HAT_ALLOWED)`) emit. Since the subgraph builds the `Creator`/`Voter` `HatPermission` rows purely from those events, **any hat granted at deployment is never indexed** (permanent, not lag).

Decentral Park's HybridVoting has emitted exactly **one** `HatSet` ever — for the Agent hat (re-set post-deploy) — which is precisely the only creator the subgraph knew about. Neighbor + Delegate were set at `initialize()` → no event → missing.

## Fix

In each voting template's `handleInitialized` — which fires *after* `initialize()` has run and the contract entity exists (the same hook `participation-token.ts` already uses to read name/symbol on-chain) — bind the contract and read the authoritative on-chain enumerations:
- **HybridVoting** → `creatorHats()` (HV voters are class-based via `handleClassesReplaced`, unchanged)
- **DirectDemocracyVoting** → `creatorHats()` + `votingHats()`

…and backfill `HatPermission` rows via a new shared util `backfillVotingHatPermissions()`.

### Safety / idempotency
- Identical `address-hatId-role` id scheme as the event handlers → no duplicates.
- Skips rows an event already wrote (events carry the authoritative `allowed` flag + precise timestamp); later grants/revokes still flow through `handleHatSet`/`handleCreatorHatSet` and override the seeded rows.
- `try_*` reads → reverting getters are tolerated (no crash, no rows).
- `hatType` left null (the array getters don't carry it; no consumer keys off it).

## Tests
- +5 HybridVoting `Initialized` cases: backfill, idempotent override, event-not-clobbered, empty, revert tolerance.
- New DirectDemocracyVoting suite: creator + voter backfill, dual-role hat, event precedence, revert tolerance.
- **Full suite: 264 passing** (`yarn test`); `yarn codegen && yarn build` clean.

## Deploy note
Existing orgs are corrected on a **full re-sync** (`handleInitialized` re-runs at each org's deploy block). A graft from the current head would only fix orgs deployed after the upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)