### PR TITLE
fix(org-registry): index post-deploy module additions (EducationHub)

### DIFF
--- a/pop-subgraph/src/org-registry.ts
+++ b/pop-subgraph/src/org-registry.ts
@@ -1,4 +1,4 @@
-import { BigInt, Bytes, DataSourceContext } from "@graphprotocol/graph-ts";
+import { Address, BigInt, Bytes, DataSourceContext } from "@graphprotocol/graph-ts";
 import {
   OrgRegistered as OrgRegisteredEvent,
   MetaUpdated as MetaUpdatedEvent,
@@ -12,11 +12,27 @@ import {
   OrgMetaUpdate,
   OrgMetadata,
   RegisteredContract,
-  SwitchableBeaconContract
+  SwitchableBeaconContract,
+  EducationHubContract,
+  ParticipationTokenContract
 } from "../generated/schema";
 import { SwitchableBeacon as SwitchableBeaconTemplate } from "../generated/templates";
 import { OrgMetadata as OrgMetadataTemplate } from "../generated/templates";
+import { EducationHub as EducationHubTemplate } from "../generated/templates";
 import { getOrCreateRole } from "./utils";
+
+// 20-byte zero address. Optional module pointers (e.g. Organization.educationHub) are set to the
+// zero-address entity at deploy time when the module was not deployed with the org.
+const ZERO_ADDRESS: Bytes = Bytes.fromHexString("0x0000000000000000000000000000000000000000");
+
+// keccak256("EducationHub") — the OrgRegistry typeId for the EducationHub module.
+// EducationHub is the only module that is OPTIONAL at org-deployment time
+// (ModulesFactory.EducationHubConfig.enabled); every other module is always deployed, and
+// OrgRegistry.registerOrgContract reverts `TypeTaken` for an already-registered type. So the
+// post-deployment registration path can only ever introduce an EducationHub today.
+const EDUCATION_HUB_TYPE_ID: Bytes = Bytes.fromHexString(
+  "0xa871f070b566fe185ede7c7d071cb2f92e7c75c6a2912b6f37c86a50cdc6bad3"
+);
 
 /**
  * Helper function to convert bytes32 sha256 digest to IPFS CIDv0.
@@ -243,6 +259,76 @@ export function handleContractRegistered(event: ContractRegisteredEvent): void {
 
   // Create dynamic data source to index SwitchableBeacon events
   SwitchableBeaconTemplate.create(beacon);
+
+  // Wire any module that is added to the org AFTER initial deployment (e.g. an EducationHub
+  // enabled via governance later). handleOrgDeployed only wires modules present at deploy time, so
+  // without this a post-hoc registration leaves Organization.educationHub pointing at the zero
+  // entity and the module's events never index.
+  wirePostDeployModule(orgId, typeId, proxy, event);
+}
+
+/**
+ * Wire a module registered AFTER the org's initial deployment into its typed Organization pointer
+ * and spin up its data-source template. No-op during the initial-deployment transaction (that is
+ * handled by handleOrgDeployed) and idempotent for modules already wired.
+ *
+ * Why this is keyed on typeId rather than handling every module: registerOrgContract reverts
+ * `TypeTaken` once a (orgId, typeId) pair is registered, so the only module that can legitimately
+ * arrive through this path is one that was absent at deploy. EducationHub is the sole optional
+ * module today; additional optional modules can be added as `else if` branches below.
+ */
+function wirePostDeployModule(orgId: Bytes, typeId: Bytes, proxy: Bytes, event: ContractRegisteredEvent): void {
+  let org = Organization.load(orgId);
+  // deployedAtBlock is null until handleOrgDeployed runs. Guarding on it makes this robust to the
+  // event ordering inside the deployment tx: if ContractRegistered fires before OrgDeployed we skip
+  // (OrgDeployed will wire the module + template), avoiding a duplicate dynamic data source.
+  if (org == null || org.deployedAtBlock === null) {
+    return;
+  }
+
+  if (typeId.equals(EDUCATION_HUB_TYPE_ID)) {
+    // Idempotent: if the org already points at a real (non-zero) EducationHub, do nothing.
+    let current = org.educationHub;
+    if (current !== null && !changetype<Bytes>(current).equals(ZERO_ADDRESS)) {
+      return;
+    }
+
+    // The module's own initializer events (TokenSet/HatsSet/ExecutorSet) were emitted before this
+    // proxy's template exists, so they will not backfill. Seed the entity from known org context
+    // instead; handleTokenSet/HatsSet/ExecutorSet will keep it current from here on.
+    let eduHub = new EducationHubContract(proxy);
+    eduHub.organization = org.id;
+    eduHub.token = org.participationToken !== null ? changetype<Bytes>(org.participationToken) : ZERO_ADDRESS;
+    eduHub.executor = org.executorContract !== null ? changetype<Bytes>(org.executorContract) : ZERO_ADDRESS;
+    eduHub.hatsContract = resolveOrgHats(org);
+    eduHub.isPaused = false;
+    eduHub.nextModuleId = BigInt.fromI32(0);
+    eduHub.createdAt = event.block.timestamp;
+    eduHub.createdAtBlock = event.block.number;
+    eduHub.save();
+
+    org.educationHub = proxy;
+    org.lastUpdatedAt = event.block.timestamp;
+    org.save();
+
+    // Index the module's modules/completions/permission changes from this block forward.
+    EducationHubTemplate.create(Address.fromBytes(proxy));
+  }
+}
+
+/**
+ * Best-effort lookup of the org's Hats Protocol address from an already-indexed module entity.
+ * Falls back to the zero address (handleHatsSet will correct it if setHats is ever called).
+ */
+function resolveOrgHats(org: Organization): Bytes {
+  let pt = org.participationToken;
+  if (pt !== null) {
+    let ptc = ParticipationTokenContract.load(changetype<Bytes>(pt));
+    if (ptc != null && !ptc.hatsContract.equals(ZERO_ADDRESS)) {
+      return ptc.hatsContract;
+    }
+  }
+  return ZERO_ADDRESS;
 }
 
 /**

--- a/pop-subgraph/tests/org-registry.test.ts
+++ b/pop-subgraph/tests/org-registry.test.ts
@@ -32,6 +32,25 @@ import {
 // Default mock event address from matchstick
 const REGISTRY_ADDRESS = "0xa16081f360e3847006db660bae1c6d1b2e17ec2a";
 
+// keccak256("EducationHub") — OrgRegistry typeId for the optional EducationHub module.
+const EDUCATION_HUB_TYPE_ID = "0xa871f070b566fe185ede7c7d071cb2f92e7c75c6a2912b6f37c86a50cdc6bad3";
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+// Helper: org deployed WITHOUT an EducationHub (educationHub points at the zero entity),
+// mirroring a real org like Decentral Park. `deployed` toggles whether OrgDeployed has run yet
+// (deployedAtBlock is null until it has).
+function createOrgWithoutEduHub(orgId: Bytes, deployed: boolean): void {
+  let org = new Organization(orgId);
+  org.executorContract = Bytes.fromHexString("0x0000000000000000000000000000000000000001");
+  org.participationToken = Bytes.fromHexString("0x0000000000000000000000000000000000000005");
+  org.educationHub = Bytes.fromHexString(ZERO_ADDRESS);
+  if (deployed) {
+    org.deployedAt = BigInt.fromI32(1000);
+    org.deployedAtBlock = BigInt.fromI32(100);
+  }
+  org.save();
+}
+
 /**
  * Helper function to convert bytes32 sha256 digest to IPFS CIDv0.
  * Mirrors the logic in org-registry.ts for test assertions.
@@ -441,6 +460,111 @@ describe("OrgRegistry", () => {
         "totalContracts",
         "2"
       );
+    });
+  });
+
+  describe("handleContractRegistered - post-deploy module wiring", () => {
+    test("wires Organization.educationHub + creates entity for a post-deploy EducationHub", () => {
+      let orgId = Bytes.fromHexString(
+        "0x1111111111111111111111111111111111111111111111111111111111111111"
+      );
+      let contractId = Bytes.fromHexString(
+        "0x7777777777777777777777777777777777777777777777777777777777777777"
+      );
+      let eduTypeId = Bytes.fromHexString(EDUCATION_HUB_TYPE_ID);
+      let proxy = Address.fromString("0x00000000000000000000000000000000000000ee");
+      let beacon = Address.fromString("0x00000000000000000000000000000000000000bb");
+      let owner = Address.fromString("0x0000000000000000000000000000000000000001");
+
+      // Org deployed without an EducationHub (the Decentral Park case).
+      createOrgWithoutEduHub(orgId, true);
+
+      let ev = createContractRegisteredEvent(contractId, orgId, eduTypeId, proxy, beacon, true, owner);
+      ev.logIndex = BigInt.fromI32(2);
+      handleContractRegistered(ev);
+
+      // The typed pointer the frontend reads now resolves to the new proxy.
+      assert.fieldEquals("Organization", orgId.toHexString(), "educationHub", proxy.toHexString());
+
+      // The referenced EducationHubContract entity exists, seeded from org context.
+      assert.entityCount("EducationHubContract", 1);
+      assert.fieldEquals("EducationHubContract", proxy.toHexString(), "organization", orgId.toHexString());
+      assert.fieldEquals(
+        "EducationHubContract",
+        proxy.toHexString(),
+        "executor",
+        "0x0000000000000000000000000000000000000001"
+      );
+      assert.fieldEquals(
+        "EducationHubContract",
+        proxy.toHexString(),
+        "token",
+        "0x0000000000000000000000000000000000000005"
+      );
+      assert.fieldEquals("EducationHubContract", proxy.toHexString(), "nextModuleId", "0");
+
+      // The generic RegisteredContract row is still written.
+      assert.entityCount("RegisteredContract", 1);
+    });
+
+    test("is idempotent - does not overwrite an already-wired EducationHub", () => {
+      let orgId = Bytes.fromHexString(
+        "0x1111111111111111111111111111111111111111111111111111111111111111"
+      );
+      let contractId = Bytes.fromHexString(
+        "0x7777777777777777777777777777777777777777777777777777777777777777"
+      );
+      let eduTypeId = Bytes.fromHexString(EDUCATION_HUB_TYPE_ID);
+      let proxy = Address.fromString("0x00000000000000000000000000000000000000ee");
+      let beacon = Address.fromString("0x00000000000000000000000000000000000000bb");
+      let owner = Address.fromString("0x0000000000000000000000000000000000000001");
+
+      // Org already has a real EducationHub (e.g. it was deployed with one).
+      let org = new Organization(orgId);
+      org.executorContract = Bytes.fromHexString("0x0000000000000000000000000000000000000001");
+      org.participationToken = Bytes.fromHexString("0x0000000000000000000000000000000000000005");
+      org.educationHub = Bytes.fromHexString("0x00000000000000000000000000000000000000aa");
+      org.deployedAtBlock = BigInt.fromI32(100);
+      org.save();
+
+      let ev = createContractRegisteredEvent(contractId, orgId, eduTypeId, proxy, beacon, true, owner);
+      ev.logIndex = BigInt.fromI32(2);
+      handleContractRegistered(ev);
+
+      // Pointer is unchanged and no new module entity is fabricated.
+      assert.fieldEquals(
+        "Organization",
+        orgId.toHexString(),
+        "educationHub",
+        "0x00000000000000000000000000000000000000aa"
+      );
+      assert.entityCount("EducationHubContract", 0);
+    });
+
+    test("skips wiring during initial deployment (deployedAtBlock null)", () => {
+      let orgId = Bytes.fromHexString(
+        "0x1111111111111111111111111111111111111111111111111111111111111111"
+      );
+      let contractId = Bytes.fromHexString(
+        "0x7777777777777777777777777777777777777777777777777777777777777777"
+      );
+      let eduTypeId = Bytes.fromHexString(EDUCATION_HUB_TYPE_ID);
+      let proxy = Address.fromString("0x00000000000000000000000000000000000000ee");
+      let beacon = Address.fromString("0x00000000000000000000000000000000000000bb");
+      let owner = Address.fromString("0x0000000000000000000000000000000000000001");
+
+      // OrgDeployed has not run yet (deployedAtBlock null); it will wire the module + template.
+      createOrgWithoutEduHub(orgId, false);
+
+      let ev = createContractRegisteredEvent(contractId, orgId, eduTypeId, proxy, beacon, true, owner);
+      ev.logIndex = BigInt.fromI32(2);
+      handleContractRegistered(ev);
+
+      // Pointer stays at the zero entity; no module entity created here.
+      assert.fieldEquals("Organization", orgId.toHexString(), "educationHub", ZERO_ADDRESS);
+      assert.entityCount("EducationHubContract", 0);
+      // The generic RegisteredContract row is still written regardless.
+      assert.entityCount("RegisteredContract", 1);
     });
   });
 


### PR DESCRIPTION
## Summary

A module added to an org **after** initial deployment (today: an `EducationHub` enabled via governance) was indexed only as a generic `RegisteredContract` row. The typed `Organization.educationHub` pointer — the field the frontend reads — stayed at the zero entity, and the module's own events (modules/completions/permissions) never indexed. This wires post-deploy module additions into the typed pointer **and** spins up the module's data-source template.

Concrete trigger: **Decentral Park** (Gnosis, orgId `0x3721…d78`) deployed without an EducationHub, then added one via a governance vote. On-chain everything is correct — `OrgRegistry.getOrgContract(org, EducationHub) = 0x80a78A0b7E0d491B7cc4cF0bAFe8bce3be9e1454`, `ParticipationToken.educationHub()` = same, `MODULE_ID()` = `0x45445548`, registered at block **46465067** — but `organization.educationHub` resolved to `0x0` in the subgraph, so the frontend showed nothing.

## Root cause

Two handlers touch org modules, and they had a coverage gap:

- **`src/org-deployer.ts` `handleOrgDeployed`** (the only place that sets typed module pointers + creates module templates) sets `organization.educationHub` (`org-deployer.ts:158`) and calls `EducationHubTemplate.create(...)` (`org-deployer.ts:208`). It fires **once** at deploy. For an org deployed without an EduHub, `event.params.educationHub` is `0x0`, so the pointer was set to the zero entity.
- **`src/org-registry.ts` `handleContractRegistered`** — the *only* handler that fires for a post-hoc `registerOrgContract` — created the `RegisteredContract` + `SwitchableBeacon` data source (`org-registry.ts:196-246`) but **never** set a typed `Organization` pointer or instantiated the module template.

So the post-hoc registration wrote a `RegisteredContract` (which is why it appeared in `registeredContracts`) but left `organization.educationHub` untouched.

## The fix

`handleContractRegistered` now calls a new `wirePostDeployModule(orgId, typeId, proxy, event)`:

- **Keyed on `typeId`.** `OrgRegistry.registerOrgContract` reverts `TypeTaken` once an `(orgId, typeId)` pair is registered, so the only module that can legitimately arrive through this path is one absent at deploy. `EducationHub` is the **only** module optional at deploy (`ModulesFactory.EducationHubConfig.enabled`); every other module is always deployed. So EduHub is the only type this path can introduce today — the handler is structured so a future optional module is a one-line `else if`.
- **Ordering-safe.** Guards on `org.deployedAtBlock` being set (null until `handleOrgDeployed` runs). If `ContractRegistered` fires before `OrgDeployed` in the deploy tx, we skip and let `OrgDeployed` wire it — avoiding a **duplicate dynamic data source**.
- **Idempotent.** If the org already points at a real (non-zero) EduHub, it's a no-op.
- **Seeds the entity from org context.** A dynamic data source only indexes from its creation block forward, and the EduHub proxy's initializer events (`TokenSet`/`HatsSet`/`ExecutorSet`) were emitted at the deploy block — *before* this template exists — so they won't backfill. The handler creates `EducationHubContract` with `token`/`executor` from the org and `hatsContract` best-effort from the indexed `ParticipationTokenContract` (with `handleHatsSet` keeping it current thereafter), rather than leaving them zero.

## Known limitation (inherent to The Graph)

A template created at registration block B cannot backfill the module's events emitted at deploy block A (A < B). For a post-hoc EduHub, this means its **creator/member `HatPermission`** rows (set during `initialize`) aren't indexed, and `token/hats/executor` come from the org-context seed rather than the init events. Modules/completions index normally from block B forward. Full historical fidelity for the pre-registration window would require a one-off backfill or contract-bound reads; out of scope here and not needed to surface the module.

## Re-sync / backfill implications

The mapping change is retroactive on a full re-index: when the subgraph re-processes Gnosis block **46465067**, Decentral Park's `organization.educationHub` will resolve to `0x80a7…1454` and the EduHub template will index from there. No data migration needed — a redeploy + re-sync picks it up. Arbitrum is unaffected (no such orgs), but the fix applies there identically.

## Testing

- `yarn codegen` ✓ · `yarn build` ✓
- `yarn test` → **267/267** pass; 3 new `org-registry` cases: post-deploy wiring, idempotency, and deploy-time skip (`deployedAtBlock` null)
- `subgraph-lint` → **0 errors** (14 pre-existing `undeclared-eth-call` warnings in `poa-manager.ts`, unrelated)

## Deploy steps (after merge)

Requires a redeploy + re-sync of both networks so the new handler runs from genesis:

```bash
cd pop-subgraph
yarn codegen && yarn build
yarn deploy:gnosis        # poa-gnosis-v-1
yarn deploy:arbitrum-one  # poa-arb-v-1
```

Verify post-sync: `organization(id: "0x3721…d78") { educationHub { id } }` returns `0x80a78A0b7E0d491B7cc4cF0bAFe8bce3be9e1454`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
