### PR TITLE
feat(org-metadata): index hours-only task payout settings

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -1779,6 +1779,13 @@ type OrgMetadata @entity(immutable: false) {
   # actual symbol (e.g. "REP") instead of the default "Shares". Stored
   # nullable so missing/old metadata defaults to "Shares" client-side.
   useTokenSymbol: Boolean
+  # When true, task payouts ignore difficulty and are computed as
+  # taskPayoutHourlyRate × estimated hours (the org "pay by hours only"
+  # setting). Nullable so missing/old metadata defaults to false client-side.
+  taskPayoutHoursOnly: Boolean
+  # Tokens-per-hour rate used when taskPayoutHoursOnly is true. Can be
+  # fractional (e.g. 12.5); frontend defaults to 10 when missing.
+  taskPayoutHourlyRate: BigDecimal
   links: [OrgMetadataLink!]! @derivedFrom(field: "metadata")
   indexedAt: BigInt
 }

--- a/pop-subgraph/src/org-metadata.ts
+++ b/pop-subgraph/src/org-metadata.ts
@@ -1,4 +1,4 @@
-import { Bytes, dataSource, json, BigInt, JSONValueKind } from "@graphprotocol/graph-ts";
+import { Bytes, dataSource, json, BigInt, BigDecimal, JSONValueKind } from "@graphprotocol/graph-ts";
 import { OrgMetadata, OrgMetadataLink } from "../generated/schema";
 
 /**
@@ -13,6 +13,8 @@ import { OrgMetadata, OrgMetadataLink } from "../generated/schema";
  *   logo: "QmXxx...",         // optional IPFS CID
  *   hideTreasury: true/false  // optional, defaults to null (= show treasury)
  *   useTokenSymbol: false     // optional, defaults to null/false
+ *   taskPayoutHoursOnly: true // optional, defaults to null/false
+ *   taskPayoutHourlyRate: 10  // optional number (tokens/hour), can be fractional
  * }
  *
  * This handler is resilient to malformed data - if parsing fails or fields
@@ -96,6 +98,28 @@ export function handleOrgMetadata(content: Bytes): void {
       useTokenSymbolValue.kind == JSONValueKind.BOOL
     ) {
       metadata.useTokenSymbol = useTokenSymbolValue.toBool();
+    }
+
+    // Parse taskPayoutHoursOnly — when true, task payouts ignore difficulty and
+    // are computed as taskPayoutHourlyRate × hours. Optional; if missing/null
+    // the frontend treats it as false.
+    let taskPayoutHoursOnlyValue = jsonObject.get("taskPayoutHoursOnly");
+    if (
+      taskPayoutHoursOnlyValue != null && !taskPayoutHoursOnlyValue.isNull() &&
+      taskPayoutHoursOnlyValue.kind == JSONValueKind.BOOL
+    ) {
+      metadata.taskPayoutHoursOnly = taskPayoutHoursOnlyValue.toBool();
+    }
+
+    // Parse taskPayoutHourlyRate — tokens-per-hour used for hours-only payouts
+    // (supports fractional values like 12.5, mirroring task estHours). Optional;
+    // the frontend defaults to 10 when missing.
+    let taskPayoutHourlyRateValue = jsonObject.get("taskPayoutHourlyRate");
+    if (
+      taskPayoutHourlyRateValue != null && !taskPayoutHourlyRateValue.isNull() &&
+      taskPayoutHourlyRateValue.kind == JSONValueKind.NUMBER
+    ) {
+      metadata.taskPayoutHourlyRate = BigDecimal.fromString(taskPayoutHourlyRateValue.toF64().toString());
     }
 
     // Set indexed timestamp (approximate - file data sources don't have block context)

--- a/pop-subgraph/tests/org-metadata.test.ts
+++ b/pop-subgraph/tests/org-metadata.test.ts
@@ -1,0 +1,119 @@
+import {
+  assert,
+  describe,
+  test,
+  clearStore,
+  afterEach,
+  dataSourceMock
+} from "matchstick-as/assembly/index";
+import { Bytes, DataSourceContext } from "@graphprotocol/graph-ts";
+import { handleOrgMetadata } from "../src/org-metadata";
+
+// Helper to convert a bytes32 sha256 digest to an IPFS CIDv0 (matches the
+// OrgMetadata entity ID the handler derives from dataSource.stringParam()).
+function bytes32ToCid(hash: Bytes): string {
+  let prefix = Bytes.fromHexString("0x1220");
+  let multihash = new Bytes(34);
+  for (let i = 0; i < 2; i++) {
+    multihash[i] = prefix[i];
+  }
+  for (let i = 0; i < 32; i++) {
+    multihash[i + 2] = hash[i];
+  }
+  return multihash.toBase58();
+}
+
+let ORG_ID = Bytes.fromHexString(
+  "0x1111111111111111111111111111111111111111111111111111111111111111"
+);
+
+// Sets up the IPFS data source mock (CID stringParam + orgId context) the way
+// handleOrgMetadata reads them, then returns the derived OrgMetadata id (CID).
+function mockOrgMetadataSource(seedHex: string): string {
+  let cid = bytes32ToCid(Bytes.fromHexString(seedHex));
+  let context = new DataSourceContext();
+  context.setBytes("orgId", ORG_ID);
+  dataSourceMock.setAddressAndContext(cid, context);
+  return cid;
+}
+
+describe("OrgMetadata IPFS Handler — task payout fields", () => {
+  afterEach(() => {
+    clearStore();
+    dataSourceMock.resetValues();
+  });
+
+  test("Parses taskPayoutHoursOnly and taskPayoutHourlyRate", () => {
+    let cid = mockOrgMetadataSource(
+      "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    );
+
+    let jsonContent =
+      '{"description":"Decentral Park","taskPayoutHoursOnly":true,"taskPayoutHourlyRate":10}';
+    handleOrgMetadata(Bytes.fromUTF8(jsonContent));
+
+    assert.entityCount("OrgMetadata", 1);
+    assert.fieldEquals("OrgMetadata", cid, "organization", ORG_ID.toHexString());
+    assert.fieldEquals("OrgMetadata", cid, "description", "Decentral Park");
+    assert.fieldEquals("OrgMetadata", cid, "taskPayoutHoursOnly", "true");
+    assert.fieldEquals("OrgMetadata", cid, "taskPayoutHourlyRate", "10");
+  });
+
+  test("Stores taskPayoutHoursOnly=false and a fractional rate", () => {
+    let cid = mockOrgMetadataSource(
+      "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+    );
+
+    let jsonContent =
+      '{"taskPayoutHoursOnly":false,"taskPayoutHourlyRate":12.5}';
+    handleOrgMetadata(Bytes.fromUTF8(jsonContent));
+
+    assert.entityCount("OrgMetadata", 1);
+    assert.fieldEquals("OrgMetadata", cid, "taskPayoutHoursOnly", "false");
+    assert.fieldEquals("OrgMetadata", cid, "taskPayoutHourlyRate", "12.5");
+  });
+
+  test("Leaves task payout fields null when missing", () => {
+    let cid = mockOrgMetadataSource(
+      "0x5555555555555555555555555555555555555555555555555555555555555555"
+    );
+
+    let jsonContent = '{"description":"No payout config here"}';
+    handleOrgMetadata(Bytes.fromUTF8(jsonContent));
+
+    // Entity is still created from the rest of the metadata; the payout fields
+    // are simply left unset (no "taskPayoutHourlyRate" key written to the store).
+    assert.entityCount("OrgMetadata", 1);
+    assert.fieldEquals("OrgMetadata", cid, "description", "No payout config here");
+  });
+
+  test("Ignores wrong-typed taskPayoutHourlyRate (string instead of number)", () => {
+    let cid = mockOrgMetadataSource(
+      "0x6666666666666666666666666666666666666666666666666666666666666666"
+    );
+
+    let jsonContent =
+      '{"taskPayoutHoursOnly":true,"taskPayoutHourlyRate":"oops"}';
+    handleOrgMetadata(Bytes.fromUTF8(jsonContent));
+
+    // Handler stays resilient: the bool still parses and the wrong-typed rate
+    // is ignored rather than bricking the entity.
+    assert.entityCount("OrgMetadata", 1);
+    assert.fieldEquals("OrgMetadata", cid, "taskPayoutHoursOnly", "true");
+  });
+
+  test("Does not regress existing metadata fields", () => {
+    let cid = mockOrgMetadataSource(
+      "0x7777777777777777777777777777777777777777777777777777777777777777"
+    );
+
+    let jsonContent =
+      '{"description":"Org","hideTreasury":true,"useTokenSymbol":true,"taskPayoutHoursOnly":true,"taskPayoutHourlyRate":10}';
+    handleOrgMetadata(Bytes.fromUTF8(jsonContent));
+
+    assert.fieldEquals("OrgMetadata", cid, "hideTreasury", "true");
+    assert.fieldEquals("OrgMetadata", cid, "useTokenSymbol", "true");
+    assert.fieldEquals("OrgMetadata", cid, "taskPayoutHoursOnly", "true");
+    assert.fieldEquals("OrgMetadata", cid, "taskPayoutHourlyRate", "10");
+  });
+});


### PR DESCRIPTION
## What

Indexes two new optional `OrgMetadata` fields so the frontend can read the new **"Pay by hours only (ignore difficulty)"** org setting from the subgraph (instead of relying on an IPFS-fallback bridge):

- `taskPayoutHoursOnly: Boolean` — when true, task payout ignores difficulty.
- `taskPayoutHourlyRate: BigDecimal` — tokens-per-hour (fractional supported; frontend defaults to 10 when missing).

When the setting is on, task payout = `taskPayoutHourlyRate × estimatedHours`.

## How

- **`schema.graphql`**: two nullable fields on `OrgMetadata`, right after `useTokenSymbol`.
- **`src/org-metadata.ts`**: parse both from the metadata IPFS JSON — the booleans follow the exact `hideTreasury` / `useTokenSymbol` pattern; the fractional rate follows the task `estHours` pattern (`BigDecimal.fromString(value.toF64().toString())`).
- **`tests/org-metadata.test.ts`** (new — the org-metadata handler had no test): parse both fields, `false` + fractional `12.5` rate, missing-field defaults, wrong-typed-rate resilience, and non-regression of `description` / `hideTreasury` / `useTokenSymbol`.

Both fields are nullable → existing orgs and already-indexed metadata are unaffected.

## Verification

`cd pop-subgraph && yarn codegen && yarn build && yarn test && subgraph-lint`

- codegen ✓ · build ✓ · **272/272 matchstick tests** ✓ · lint **0 errors** (14 pre-existing `undeclared-eth-call` warnings, unrelated)

## Frontend coordination

The frontend already writes these fields into the org metadata JSON and reads them via an IPFS-fallback bridge, so the feature works today. Once this PR deploys and re-indexes, the frontend can add `taskPayoutHoursOnly` / `taskPayoutHourlyRate` to `FETCH_ORG_FULL_DATA` to read straight from the subgraph. **That frontend query change must land only after this is deployed** — querying the fields before the schema ships would error the whole org query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)