### PR TITLE
fix(task-metadata): scope entity id by taskId to fix batch collision

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -359,7 +359,7 @@ Task metadata fetched from IPFS.
 Contains task description, difficulty, estimated hours, and submission content.
 """
 type TaskMetadata @entity(immutable: false) {
-  id: String! # txHash-ipfsCid (e.g. 0xabc...-Qm...)
+  id: String! # taskId-ipfsCid, i.e. taskManager-taskId-CID (e.g. 0xTaskManager...-2-Qm...). Scoped by taskId (not tx hash) so batch-created tasks with identical metadata don't collide.
   task: Task # Link back to the task
   name: String # Task name from IPFS JSON
   description: String # Task description from IPFS JSON

--- a/pop-subgraph/src/task-manager.ts
+++ b/pop-subgraph/src/task-manager.ts
@@ -77,8 +77,16 @@ function bytes32ToCid(hash: Bytes): string {
  *
  * Uses DataSourceContext to pass taskId and timestamp to the handler so it can
  * link the metadata back to the task and record when it was indexed.
+ *
+ * The TaskMetadata entity id is scoped by taskId (taskManager-taskId), NOT by tx
+ * hash. Batch task creation emits several TaskCreated events in one transaction
+ * (one tx hash); tasks with identical metadata (e.g. same title) produce the same
+ * CID. A txHash-CID id would collide across those tasks, spawning two file data
+ * sources that write the same entity id in the same block — which graph-node
+ * rejects ("can not append operations that go backwards"). taskId is unique per
+ * task, so taskId-CID never collides. Keep this in sync with task-metadata.ts.
  */
-function createTaskMetadataSource(metadataHash: Bytes, taskId: string, timestamp: BigInt, txHash: Bytes): void {
+function createTaskMetadataSource(metadataHash: Bytes, taskId: string, timestamp: BigInt): void {
   // Skip if metadataHash is empty (all zeros)
   let zeroHash = Bytes.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000000");
   if (metadataHash.equals(zeroHash)) {
@@ -88,8 +96,8 @@ function createTaskMetadataSource(metadataHash: Bytes, taskId: string, timestamp
   // Convert bytes32 sha256 digest to IPFS CIDv0 string
   let ipfsCid = bytes32ToCid(metadataHash);
 
-  // Entity ID includes tx hash for uniqueness
-  let entityId = txHash.toHexString() + "-" + ipfsCid;
+  // Entity ID is scoped by the (globally unique) task id for uniqueness
+  let entityId = taskId + "-" + ipfsCid;
 
   // Skip if TaskMetadata already exists (from previous blocks)
   let existingMetadata = TaskMetadata.load(entityId);
@@ -97,11 +105,10 @@ function createTaskMetadataSource(metadataHash: Bytes, taskId: string, timestamp
     return;
   }
 
-  // Create context to pass taskId, timestamp, and txHash to the IPFS handler
+  // Create context to pass taskId and timestamp to the IPFS handler
   let context = new DataSourceContext();
   context.setString("taskId", taskId);
   context.setBigInt("timestamp", timestamp);
-  context.setBytes("txHash", txHash);
 
   // Create the file data source with context
   TaskMetadataTemplate.createWithContext(ipfsCid, context);
@@ -207,14 +214,14 @@ export function handleTaskCreated(event: TaskCreated): void {
   task.createdAt = event.block.timestamp;
   task.createdAtBlock = event.block.number;
 
-  // Set metadata link using txHash-CID format for uniqueness
+  // Set metadata link using taskId-CID format for uniqueness
   let metadataCid = bytes32ToCid(event.params.metadataHash);
-  task.metadata = event.transaction.hash.toHexString() + "-" + metadataCid;
+  task.metadata = id + "-" + metadataCid;
 
   task.save();
 
   // Create IPFS data source to fetch and index task metadata
-  createTaskMetadataSource(event.params.metadataHash, id, event.block.timestamp, event.transaction.hash);
+  createTaskMetadataSource(event.params.metadataHash, id, event.block.timestamp);
 }
 
 export function handleTaskAssigned(event: TaskAssigned): void {
@@ -272,14 +279,14 @@ export function handleTaskSubmitted(event: TaskSubmitted): void {
     task.submittedAt = event.block.timestamp;
     task.submissionHash = event.params.submissionHash;
 
-    // Update metadata link to submission content using txHash-CID format
+    // Update metadata link to submission content using taskId-CID format
     let submissionCid = bytes32ToCid(event.params.submissionHash);
-    task.metadata = event.transaction.hash.toHexString() + "-" + submissionCid;
+    task.metadata = id + "-" + submissionCid;
 
     task.save();
 
     // Create IPFS data source to fetch and parse submission metadata
-    createTaskMetadataSource(event.params.submissionHash, id, event.block.timestamp, event.transaction.hash);
+    createTaskMetadataSource(event.params.submissionHash, id, event.block.timestamp);
   }
 }
 
@@ -372,17 +379,17 @@ export function handleTaskUpdated(event: TaskUpdated): void {
     task.metadataHash = event.params.metadataHash;
     task.updatedAt = event.block.timestamp;
 
-    // Update metadata link if changed - uses txHash-CID as entity ID
+    // Update metadata link if changed - uses taskId-CID as entity ID
     if (metadataChanged) {
       let metadataCid = bytes32ToCid(event.params.metadataHash);
-      task.metadata = event.transaction.hash.toHexString() + "-" + metadataCid;
+      task.metadata = id + "-" + metadataCid;
     }
 
     task.save();
 
     // Re-fetch metadata from IPFS if it changed
     if (metadataChanged) {
-      createTaskMetadataSource(event.params.metadataHash, id, event.block.timestamp, event.transaction.hash);
+      createTaskMetadataSource(event.params.metadataHash, id, event.block.timestamp);
     }
   }
 }
@@ -692,15 +699,15 @@ export function handleTaskRejected(event: TaskRejected): void {
   // handleTaskSubmitted overwrites task.metadata to point at submission content;
   // on rejection we need to point it back to the task description metadata.
   let originalCid = bytes32ToCid(task.metadataHash);
-  task.metadata = event.transaction.hash.toHexString() + "-" + originalCid;
+  task.metadata = taskEntityId + "-" + originalCid;
 
   task.save();
 
   // Re-fetch original task description metadata from IPFS so the restored link resolves
-  createTaskMetadataSource(task.metadataHash, taskEntityId, event.block.timestamp, event.transaction.hash);
+  createTaskMetadataSource(task.metadataHash, taskEntityId, event.block.timestamp);
 
   // Create IPFS data source to fetch and parse rejection metadata
-  createTaskMetadataSource(event.params.rejectionHash, taskEntityId, event.block.timestamp, event.transaction.hash);
+  createTaskMetadataSource(event.params.rejectionHash, taskEntityId, event.block.timestamp);
 
   // Create rejection record
   let rejectionId = event.transaction.hash.concatI32(event.logIndex.toI32());
@@ -710,9 +717,10 @@ export function handleTaskRejected(event: TaskRejected): void {
   rejection.rejectorUsername = getUsernameForAddress(event.params.rejector);
   rejection.rejectionHash = event.params.rejectionHash;
 
-  // Link to rejection metadata entity (will be created by IPFS data source)
+  // Link to rejection metadata entity (will be created by IPFS data source).
+  // Scoped by taskId-CID to match the TaskMetadata entity the IPFS handler creates.
   let rejectionCid = bytes32ToCid(event.params.rejectionHash);
-  rejection.metadata = event.transaction.hash.toHexString() + "-" + rejectionCid;
+  rejection.metadata = taskEntityId + "-" + rejectionCid;
   rejection.rejectedAt = event.block.timestamp;
   rejection.rejectedAtBlock = event.block.number;
   rejection.transactionHash = event.transaction.hash;

--- a/pop-subgraph/src/task-metadata.ts
+++ b/pop-subgraph/src/task-metadata.ts
@@ -4,19 +4,26 @@ import { TaskMetadata } from "../generated/schema";
 /**
  * Handler for IPFS file data source that parses task metadata JSON.
  *
- * Creates a mutable TaskMetadata entity keyed by txHash-CID for uniqueness.
+ * Creates a mutable TaskMetadata entity keyed by taskId-CID for uniqueness.
  * Uses "load or create" pattern which is safe for mutable entities and
  * handles retries gracefully without triggering duplicate key constraint violations.
+ *
+ * The ID MUST be scoped by taskId (not tx hash): when several tasks are created
+ * in one batch transaction they share a tx hash, and identical task metadata
+ * (e.g. same title) yields an identical CID. A txHash-CID key would then collide
+ * across those tasks, producing two file data sources that write the same entity
+ * id in the same block — which graph-node rejects with
+ * "can not append operations that go backwards". taskId is globally unique
+ * (taskManager-taskId), so taskId-CID is collision-free.
  */
 export function handleTaskMetadata(content: Bytes): void {
   let ipfsCid = dataSource.stringParam();
   let context = dataSource.context();
   let taskId = context.getString("taskId");
   let timestamp = context.getBigInt("timestamp");
-  let txHash = context.getBytes("txHash");
 
-  // Entity ID includes tx hash for uniqueness
-  let entityId = txHash.toHexString() + "-" + ipfsCid;
+  // Entity ID is scoped by the (globally unique) task id for uniqueness
+  let entityId = taskId + "-" + ipfsCid;
 
   // Load or create metadata entity (mutable entity - safe to update)
   let metadata = TaskMetadata.load(entityId);

--- a/pop-subgraph/tests/task-manager.test.ts
+++ b/pop-subgraph/tests/task-manager.test.ts
@@ -37,7 +37,7 @@ import {
   createOrganizerHatAllowedEvent,
   createRolePermSetEvent
 } from "./task-manager-utils";
-import { Organization, TaskManager, HybridVotingContract, DirectDemocracyVotingContract, EligibilityModuleContract, ParticipationTokenContract, QuickJoinContract, EducationHubContract, PaymentManagerContract, ExecutorContract, ToggleModuleContract } from "../generated/schema";
+import { Task, Organization, TaskManager, HybridVotingContract, DirectDemocracyVotingContract, EligibilityModuleContract, ParticipationTokenContract, QuickJoinContract, EducationHubContract, PaymentManagerContract, ExecutorContract, ToggleModuleContract } from "../generated/schema";
 
 /**
  * Helper function to create necessary entities for task manager tests.
@@ -286,6 +286,72 @@ describe("TaskManager", () => {
     assert.fieldEquals("Task", expectedTaskId, "requiresApplication", "true");
     // Verify task links to composite project ID
     assert.fieldEquals("Task", expectedTaskId, "project", expectedProjectId);
+  });
+
+  test("Batch-created tasks with identical metadata get distinct, task-scoped metadata links", () => {
+    // Regression test for the graph-node indexing error:
+    //   "can not append operations that go backwards from Insert { TaskMetadata[...] }"
+    // Tasks created in ONE batch transaction share a tx hash, and tasks with
+    // identical metadata (e.g. the same title) produce an identical IPFS CID.
+    // The old txHash-CID entity id collided across those tasks, spawning two file
+    // data sources that wrote the same TaskMetadata id in the same block. The id
+    // is now scoped by taskId (taskManager-taskId), so the links must differ.
+    setupTaskManagerEntities();
+
+    let projectId = Bytes.fromHexString(
+      "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    );
+    let projectEvent = createProjectCreatedEvent(
+      projectId,
+      Bytes.fromHexString("0xabcd"),
+      Bytes.fromHexString("0x0000000000000000000000000000000000000000000000000000000000001234"),
+      BigInt.fromI32(1000)
+    );
+    handleProjectCreated(projectEvent);
+
+    // Same title + same metadata hash => same CID. createTaskCreatedEvent reuses
+    // newMockEvent()'s default transaction hash, so both share a tx hash (batch).
+    let sharedTitle = Bytes.fromHexString("0x48656c70206d6f7665"); // "Help move"
+    let sharedMetadataHash = Bytes.fromHexString(
+      "0x00000000000000000000000000000000000000000000000000000000deadbeef"
+    );
+    let bountyToken = Address.fromString("0x0000000000000000000000000000000000000001");
+
+    let event2 = createTaskCreatedEvent(
+      BigInt.fromI32(2), projectId, BigInt.fromI32(100), bountyToken,
+      BigInt.fromI32(0), false, sharedTitle, sharedMetadataHash
+    );
+    handleTaskCreated(event2);
+
+    let event3 = createTaskCreatedEvent(
+      BigInt.fromI32(3), projectId, BigInt.fromI32(100), bountyToken,
+      BigInt.fromI32(0), false, sharedTitle, sharedMetadataHash
+    );
+    handleTaskCreated(event3);
+
+    assert.entityCount("Task", 2);
+
+    let id2 = "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-2";
+    let id3 = "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-3";
+    let task2 = Task.load(id2);
+    let task3 = Task.load(id3);
+    assert.assertTrue(task2 != null);
+    assert.assertTrue(task3 != null);
+
+    let meta2 = task2!.metadata;
+    let meta3 = task3!.metadata;
+    assert.assertTrue(meta2 != null);
+    assert.assertTrue(meta3 != null);
+
+    // Core guard: identical-metadata batch tasks must NOT share a TaskMetadata id.
+    assert.assertTrue(meta2 != meta3);
+
+    // Each link is scoped by its own task id and shares the same CID suffix.
+    let cid2 = meta2!.substring((id2 + "-").length);
+    let cid3 = meta3!.substring((id3 + "-").length);
+    assert.assertTrue(cid2 == cid3);
+    assert.fieldEquals("Task", id2, "metadata", id2 + "-" + cid2);
+    assert.fieldEquals("Task", id3, "metadata", id3 + "-" + cid2);
   });
 
   test("Task assigned updates status", () => {


### PR DESCRIPTION
Batch task creation emits multiple `TaskCreated` events in one transaction, and tasks with identical metadata (e.g. the same title) produce the same IPFS CID — so the old `txHash-CID` `TaskMetadata` id collided across those tasks. The two file data sources then wrote that same entity id in the same block, which graph-node rejects with "can not append operations that go backwards", halting indexing at block 46497604. This scopes the `TaskMetadata` id by the globally-unique task id (`taskManager-taskId`) instead — matching the pattern `ProposalMetadata` already uses — updating all link assignments and removing the now-dead `txHash` plumbing. A regression test reproduces the batch (same tx hash + same `metadataHash`) and asserts distinct, task-scoped links; `codegen`/`build`/`test` (273 pass, incl. the new test) and `subgraph-lint` (0 errors) all pass. Note: this changes the `TaskMetadata` id scheme, so deploying it needs a new subgraph version (full resync, or graft from just before block 46497604).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
