### PR TITLE
fix(task-metadata): dedupe same-task metadata re-refs across blocks

### DIFF
--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -368,7 +368,7 @@ type TaskMetadata @entity(immutable: false) {
   estimatedHours: BigDecimal # Estimated hours to complete (can be fractional, e.g. 0.5)
   submission: String # Submission content from IPFS JSON (for submission metadata)
   rejection: String # Rejection reason from IPFS JSON (for rejection metadata)
-  indexedAt: BigInt # When this metadata was indexed
+  indexedAt: BigInt # Deprecated: no longer populated. A per-block timestamp can't live in the file-data-source context without breaking dedup; use Task.createdAt/updatedAt instead.
 }
 
 type TaskApplication @entity(immutable: false) {

--- a/pop-subgraph/src/task-manager.ts
+++ b/pop-subgraph/src/task-manager.ts
@@ -75,18 +75,29 @@ function bytes32ToCid(hash: Bytes): string {
 /**
  * Helper function to create an IPFS file data source for task metadata.
  *
- * Uses DataSourceContext to pass taskId and timestamp to the handler so it can
- * link the metadata back to the task and record when it was indexed.
+ * `taskId` here is the globally-unique task entity id (taskManager-taskId), so it
+ * is org-scoped — on-chain task ids repeat across orgs, the TaskManager address
+ * disambiguates. The TaskMetadata entity id is `taskId-CID` for two reasons:
  *
- * The TaskMetadata entity id is scoped by taskId (taskManager-taskId), NOT by tx
- * hash. Batch task creation emits several TaskCreated events in one transaction
- * (one tx hash); tasks with identical metadata (e.g. same title) produce the same
- * CID. A txHash-CID id would collide across those tasks, spawning two file data
- * sources that write the same entity id in the same block — which graph-node
- * rejects ("can not append operations that go backwards"). taskId is unique per
- * task, so taskId-CID never collides. Keep this in sync with task-metadata.ts.
+ *   1. Cross-task: batch task creation emits several TaskCreated events in one tx
+ *      (one tx hash); tasks with identical metadata produce the same CID. A
+ *      txHash-CID id collided across those tasks, writing the same entity id in
+ *      one block ("can not append operations that go backwards").
+ *
+ *   2. Same task, later block: a task can re-reference the same metadata in a
+ *      later tx (e.g. TaskRejected restoring the original description), which runs
+ *      this file data source again. graph-node dedupes file data sources by
+ *      (template, CID, context), so the context MUST be identical across those
+ *      references. We therefore pass ONLY taskId — no per-block timestamp. A
+ *      timestamp here defeated dedup and produced two Inserts of the same id
+ *      ("impossible combination of entity operations").
+ *
+ * The TaskMetadata.load guard below only sees writes from this (onchain) causality
+ * region, never the file data source's, so it does not prevent the duplicate — the
+ * graph-node host dedup above is what does. It is kept as a cheap same-region
+ * safety net. Keep this in sync with task-metadata.ts.
  */
-function createTaskMetadataSource(metadataHash: Bytes, taskId: string, timestamp: BigInt): void {
+function createTaskMetadataSource(metadataHash: Bytes, taskId: string): void {
   // Skip if metadataHash is empty (all zeros)
   let zeroHash = Bytes.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000000");
   if (metadataHash.equals(zeroHash)) {
@@ -99,16 +110,16 @@ function createTaskMetadataSource(metadataHash: Bytes, taskId: string, timestamp
   // Entity ID is scoped by the (globally unique) task id for uniqueness
   let entityId = taskId + "-" + ipfsCid;
 
-  // Skip if TaskMetadata already exists (from previous blocks)
+  // Same-region safety net (see note above); cross-block dedup is handled by graph-node
   let existingMetadata = TaskMetadata.load(entityId);
   if (existingMetadata != null) {
     return;
   }
 
-  // Create context to pass taskId and timestamp to the IPFS handler
+  // Context carries ONLY taskId so repeated references to the same (task, CID)
+  // dedupe to a single file data source — do NOT add per-block fields here.
   let context = new DataSourceContext();
   context.setString("taskId", taskId);
-  context.setBigInt("timestamp", timestamp);
 
   // Create the file data source with context
   TaskMetadataTemplate.createWithContext(ipfsCid, context);
@@ -221,7 +232,7 @@ export function handleTaskCreated(event: TaskCreated): void {
   task.save();
 
   // Create IPFS data source to fetch and index task metadata
-  createTaskMetadataSource(event.params.metadataHash, id, event.block.timestamp);
+  createTaskMetadataSource(event.params.metadataHash, id);
 }
 
 export function handleTaskAssigned(event: TaskAssigned): void {
@@ -286,7 +297,7 @@ export function handleTaskSubmitted(event: TaskSubmitted): void {
     task.save();
 
     // Create IPFS data source to fetch and parse submission metadata
-    createTaskMetadataSource(event.params.submissionHash, id, event.block.timestamp);
+    createTaskMetadataSource(event.params.submissionHash, id);
   }
 }
 
@@ -389,7 +400,7 @@ export function handleTaskUpdated(event: TaskUpdated): void {
 
     // Re-fetch metadata from IPFS if it changed
     if (metadataChanged) {
-      createTaskMetadataSource(event.params.metadataHash, id, event.block.timestamp);
+      createTaskMetadataSource(event.params.metadataHash, id);
     }
   }
 }
@@ -703,11 +714,12 @@ export function handleTaskRejected(event: TaskRejected): void {
 
   task.save();
 
-  // Re-fetch original task description metadata from IPFS so the restored link resolves
-  createTaskMetadataSource(task.metadataHash, taskEntityId, event.block.timestamp);
+  // Re-fetch original task description metadata from IPFS so the restored link resolves.
+  // Same (task, CID) as creation -> graph-node dedupes this to the existing file data source.
+  createTaskMetadataSource(task.metadataHash, taskEntityId);
 
   // Create IPFS data source to fetch and parse rejection metadata
-  createTaskMetadataSource(event.params.rejectionHash, taskEntityId, event.block.timestamp);
+  createTaskMetadataSource(event.params.rejectionHash, taskEntityId);
 
   // Create rejection record
   let rejectionId = event.transaction.hash.concatI32(event.logIndex.toI32());

--- a/pop-subgraph/src/task-metadata.ts
+++ b/pop-subgraph/src/task-metadata.ts
@@ -1,26 +1,35 @@
-import { BigDecimal, BigInt, Bytes, dataSource, json, JSONValueKind } from "@graphprotocol/graph-ts";
+import { BigDecimal, Bytes, dataSource, json, JSONValueKind } from "@graphprotocol/graph-ts";
 import { TaskMetadata } from "../generated/schema";
 
 /**
  * Handler for IPFS file data source that parses task metadata JSON.
  *
- * Creates a mutable TaskMetadata entity keyed by taskId-CID for uniqueness.
- * Uses "load or create" pattern which is safe for mutable entities and
- * handles retries gracefully without triggering duplicate key constraint violations.
+ * The entity ID is `taskId-CID` where taskId is the globally-unique task entity id
+ * (taskManager-taskId, so it is org-scoped — on-chain task ids repeat across orgs).
+ * This must hold for two independent reasons, both of which otherwise crash the
+ * indexer because file data sources run in isolated causality regions:
  *
- * The ID MUST be scoped by taskId (not tx hash): when several tasks are created
- * in one batch transaction they share a tx hash, and identical task metadata
- * (e.g. same title) yields an identical CID. A txHash-CID key would then collide
- * across those tasks, producing two file data sources that write the same entity
- * id in the same block — which graph-node rejects with
- * "can not append operations that go backwards". taskId is globally unique
- * (taskManager-taskId), so taskId-CID is collision-free.
+ *   1. Cross-task: batch-created tasks share a tx hash, and identical metadata
+ *      (e.g. same title) yields the same CID. A txHash-CID key would collide
+ *      across those tasks ("can not append operations that go backwards").
+ *
+ *   2. Same task, different blocks: when a task re-references the same metadata
+ *      later (e.g. TaskRejected restoring the original description), the indexer
+ *      runs the file data source again. graph-node deduplicates file data sources
+ *      by (template, CID, context), so the context MUST be identical across those
+ *      references for the duplicate to be dropped. We therefore pass ONLY taskId
+ *      (no per-block timestamp) — a timestamp in the context defeated dedup and
+ *      produced two Inserts of the same id ("impossible combination of entity
+ *      operations"). This mirrors the ProposalMetadata pattern.
+ *
+ * `indexedAt` is intentionally not populated (kept nullable for backward compat):
+ * a per-block timestamp cannot live in the context without breaking dedup, and the
+ * task's own createdAt/updatedAt already carry that information.
  */
 export function handleTaskMetadata(content: Bytes): void {
   let ipfsCid = dataSource.stringParam();
   let context = dataSource.context();
   let taskId = context.getString("taskId");
-  let timestamp = context.getBigInt("timestamp");
 
   // Entity ID is scoped by the (globally unique) task id for uniqueness
   let entityId = taskId + "-" + ipfsCid;
@@ -30,7 +39,6 @@ export function handleTaskMetadata(content: Bytes): void {
   if (metadata == null) {
     metadata = new TaskMetadata(entityId);
     metadata.task = taskId;
-    metadata.indexedAt = timestamp;
   }
 
   // Try to parse the JSON content

--- a/pop-subgraph/tests/task-manager.test.ts
+++ b/pop-subgraph/tests/task-manager.test.ts
@@ -354,6 +354,72 @@ describe("TaskManager", () => {
     assert.fieldEquals("Task", id3, "metadata", id3 + "-" + cid2);
   });
 
+  test("Same task re-referencing identical metadata across txs keeps a stable link", () => {
+    // Regression test for the second graph-node indexing error:
+    //   "impossible combination of entity operations: Insert { TaskMetadata[...] }
+    //    and then Insert { ... }"
+    // A task can re-reference the SAME metadata in a LATER tx/block (TaskRejected
+    // restores the original description). The file data source then runs again;
+    // graph-node dedupes file data sources by (template, CID, context), so the
+    // context carries ONLY taskId (no per-block timestamp) and the metadata link id
+    // is identical to the one set at creation, regardless of tx/block. With the old
+    // txHash-CID id the restored link differed, producing a duplicate insert.
+    setupTaskManagerEntities();
+
+    let projectId = Bytes.fromHexString(
+      "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    );
+    let projectEvent = createProjectCreatedEvent(
+      projectId,
+      Bytes.fromHexString("0xabcd"),
+      Bytes.fromHexString("0x0000000000000000000000000000000000000000000000000000000000001234"),
+      BigInt.fromI32(1000)
+    );
+    handleProjectCreated(projectEvent);
+
+    let taskId = BigInt.fromI32(0);
+    let title = Bytes.fromHexString("0x4164646578656373"); // "Addexecs"
+    let metadataHash = Bytes.fromHexString(
+      "0x00000000000000000000000000000000000000000000000000000000deadbeef"
+    );
+    let bountyToken = Address.fromString("0x0000000000000000000000000000000000000001");
+
+    // Create the task in tx 0xaa...
+    let createEvent = createTaskCreatedEvent(
+      taskId, projectId, BigInt.fromI32(100), bountyToken,
+      BigInt.fromI32(0), false, title, metadataHash
+    );
+    createEvent.transaction.hash = Bytes.fromHexString(
+      "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    );
+    handleTaskCreated(createEvent);
+
+    let entityId = "0xa16081f360e3847006db660bae1c6d1b2e17ec2a-0";
+    let taskAfterCreate = Task.load(entityId);
+    assert.assertTrue(taskAfterCreate != null);
+    let linkAfterCreate = taskAfterCreate!.metadata;
+    assert.assertTrue(linkAfterCreate != null);
+    // Link is task-scoped (starts with the task entity id), never tx-scoped.
+    assert.assertTrue(linkAfterCreate!.substring(0, (entityId + "-").length) == entityId + "-");
+
+    // Reject in a DIFFERENT tx 0xbb... -> restores task.metadata to the original
+    // description metadata (re-referencing the same CID at a later block).
+    let rejector = Address.fromString("0x0000000000000000000000000000000000000003");
+    let rejectionHash = Bytes.fromHexString(
+      "0x00000000000000000000000000000000000000000000000000000000feedface"
+    );
+    let rejectEvent = createTaskRejectedEvent(taskId, rejector, rejectionHash);
+    rejectEvent.transaction.hash = Bytes.fromHexString(
+      "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    );
+    rejectEvent.logIndex = BigInt.fromI32(1);
+    handleTaskRejected(rejectEvent);
+
+    // Restored link must be byte-identical to the creation link: stable across txs.
+    // (Old txHash-CID id would differ here, since the two events have different hashes.)
+    assert.fieldEquals("Task", entityId, "metadata", linkAfterCreate!);
+  });
+
   test("Task assigned updates status", () => {
     // Setup Organization and TaskManager entities first
     setupTaskManagerEntities();


### PR DESCRIPTION
Follow-up to #189: that fix scoped the `TaskMetadata` id by `taskId` (killing cross-task batch collisions) but left a per-block `timestamp` in the file-data-source `DataSourceContext`. When a task re-references the same metadata in a later block (e.g. `TaskRejected` restoring the original description), graph-node re-runs the file data source — and since it dedupes file data sources by `(template, CID, context)`, the differing timestamp defeated dedup and produced two inserts of the same `taskId-CID` id across blocks: `"impossible combination of entity operations"`, halting indexing at block 45443920. This passes **only** `taskId` (the org-scoped `taskManager-taskId`, so on-chain ids that repeat across orgs stay distinct) in the context — matching the already-correct `ProposalMetadata` pattern — so repeated references to the same `(task, CID)` collapse to one file data source; `indexedAt` can no longer be sourced without re-breaking dedup, so it is left null and deprecated (unused by the frontend — use `Task.createdAt/updatedAt`). Adds a regression test that re-references identical metadata across two different tx hashes and asserts a stable, task-scoped link. Verified: `codegen`/`build`/`test` (274 pass) and `subgraph-lint` (0 errors); deploying needs a new subgraph version + resync (or graft from just before block 45443920).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
