### PR TITLE
feat: index ZkEmailInvites email allowlist (active root/cid + parsed entries)

### DIFF
--- a/pop-subgraph/abis/ZkEmailInvites.json
+++ b/pop-subgraph/abis/ZkEmailInvites.json
@@ -1,0 +1,982 @@
+[
+  {
+    "type": "constructor",
+    "inputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "MODULE_ID",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes4",
+        "internalType": "bytes4"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "accountRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IUniversalAccountRegistry"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "allowlistCid",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "claimRoleByDomain",
+    "inputs": [
+      {
+        "name": "proof",
+        "type": "tuple",
+        "internalType": "struct ZkEmailProof",
+        "components": [
+          {
+            "name": "pA",
+            "type": "uint256[2]",
+            "internalType": "uint256[2]"
+          },
+          {
+            "name": "pB",
+            "type": "uint256[2][2]",
+            "internalType": "uint256[2][2]"
+          },
+          {
+            "name": "pC",
+            "type": "uint256[2]",
+            "internalType": "uint256[2]"
+          },
+          {
+            "name": "pubkeyHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "emailNullifier",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "domainName",
+            "type": "string",
+            "internalType": "string"
+          }
+        ]
+      },
+      {
+        "name": "claimer",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "hatIds",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "merkleProof",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "claimRoleByEmail",
+    "inputs": [
+      {
+        "name": "proof",
+        "type": "tuple",
+        "internalType": "struct ZkEmailProofV2",
+        "components": [
+          {
+            "name": "pA",
+            "type": "uint256[2]",
+            "internalType": "uint256[2]"
+          },
+          {
+            "name": "pB",
+            "type": "uint256[2][2]",
+            "internalType": "uint256[2][2]"
+          },
+          {
+            "name": "pC",
+            "type": "uint256[2]",
+            "internalType": "uint256[2]"
+          },
+          {
+            "name": "pubkeyHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "emailNullifier",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "domainName",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "emailHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          }
+        ]
+      },
+      {
+        "name": "claimer",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "hatIds",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "merkleProof",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "dkimRegistry",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IDKIMRegistry"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "domainVerifier",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IZkEmailGroth16Verifier"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "emailVerifier",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IZkEmailGroth16VerifierV2"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "executor",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "initialize",
+    "inputs": [
+      {
+        "name": "executor_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "domainVerifier_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "emailVerifier_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "dkimRegistry_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "accountRegistry_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "universalFactory_",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "initialRoot",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "initialCid",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "isNullifierUsed",
+    "inputs": [
+      {
+        "name": "n",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "merkleRoot",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "registerAndClaimByDomainWithPasskey",
+    "inputs": [
+      {
+        "name": "passkey",
+        "type": "tuple",
+        "internalType": "struct ZkEmailInvites.PasskeyEnrollment",
+        "components": [
+          {
+            "name": "credentialId",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "publicKeyX",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "publicKeyY",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "salt",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      },
+      {
+        "name": "username",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "deadline",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "nonce",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "auth",
+        "type": "tuple",
+        "internalType": "struct WebAuthnLib.WebAuthnAuth",
+        "components": [
+          {
+            "name": "authenticatorData",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "clientDataJSON",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "challengeIndex",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "typeIndex",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "r",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "s",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          }
+        ]
+      },
+      {
+        "name": "proof",
+        "type": "tuple",
+        "internalType": "struct ZkEmailProof",
+        "components": [
+          {
+            "name": "pA",
+            "type": "uint256[2]",
+            "internalType": "uint256[2]"
+          },
+          {
+            "name": "pB",
+            "type": "uint256[2][2]",
+            "internalType": "uint256[2][2]"
+          },
+          {
+            "name": "pC",
+            "type": "uint256[2]",
+            "internalType": "uint256[2]"
+          },
+          {
+            "name": "pubkeyHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "emailNullifier",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "domainName",
+            "type": "string",
+            "internalType": "string"
+          }
+        ]
+      },
+      {
+        "name": "hatIds",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "merkleProof",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "registerAndClaimByEmailWithPasskey",
+    "inputs": [
+      {
+        "name": "passkey",
+        "type": "tuple",
+        "internalType": "struct ZkEmailInvites.PasskeyEnrollment",
+        "components": [
+          {
+            "name": "credentialId",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "publicKeyX",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "publicKeyY",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "salt",
+            "type": "uint256",
+            "internalType": "uint256"
+          }
+        ]
+      },
+      {
+        "name": "username",
+        "type": "string",
+        "internalType": "string"
+      },
+      {
+        "name": "deadline",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "nonce",
+        "type": "uint256",
+        "internalType": "uint256"
+      },
+      {
+        "name": "auth",
+        "type": "tuple",
+        "internalType": "struct WebAuthnLib.WebAuthnAuth",
+        "components": [
+          {
+            "name": "authenticatorData",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "clientDataJSON",
+            "type": "bytes",
+            "internalType": "bytes"
+          },
+          {
+            "name": "challengeIndex",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "typeIndex",
+            "type": "uint256",
+            "internalType": "uint256"
+          },
+          {
+            "name": "r",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "s",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          }
+        ]
+      },
+      {
+        "name": "proof",
+        "type": "tuple",
+        "internalType": "struct ZkEmailProofV2",
+        "components": [
+          {
+            "name": "pA",
+            "type": "uint256[2]",
+            "internalType": "uint256[2]"
+          },
+          {
+            "name": "pB",
+            "type": "uint256[2][2]",
+            "internalType": "uint256[2][2]"
+          },
+          {
+            "name": "pC",
+            "type": "uint256[2]",
+            "internalType": "uint256[2]"
+          },
+          {
+            "name": "pubkeyHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "emailNullifier",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          },
+          {
+            "name": "domainName",
+            "type": "string",
+            "internalType": "string"
+          },
+          {
+            "name": "emailHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
+          }
+        ]
+      },
+      {
+        "name": "hatIds",
+        "type": "uint256[]",
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "merkleProof",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setAccountRegistry",
+    "inputs": [
+      {
+        "name": "r",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setActiveAllowlist",
+    "inputs": [
+      {
+        "name": "root",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      },
+      {
+        "name": "cid",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setDKIMRegistry",
+    "inputs": [
+      {
+        "name": "d",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setDomainVerifier",
+    "inputs": [
+      {
+        "name": "v",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setEmailVerifier",
+    "inputs": [
+      {
+        "name": "v",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setUniversalFactory",
+    "inputs": [
+      {
+        "name": "f",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "universalFactory",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "contract IUniversalPasskeyAccountFactory"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "event",
+    "name": "AccountRegistryUpdated",
+    "inputs": [
+      {
+        "name": "registry",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "ActiveAllowlistSet",
+    "inputs": [
+      {
+        "name": "merkleRoot",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "allowlistCid",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DKIMRegistryUpdated",
+    "inputs": [
+      {
+        "name": "registry",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "DomainVerifierUpdated",
+    "inputs": [
+      {
+        "name": "verifier",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "EmailVerifierUpdated",
+    "inputs": [
+      {
+        "name": "verifier",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Initialized",
+    "inputs": [
+      {
+        "name": "version",
+        "type": "uint64",
+        "indexed": false,
+        "internalType": "uint64"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RegisteredAndClaimedByDomain",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "credentialId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "username",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "domainHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "hatIds",
+        "type": "uint256[]",
+        "indexed": false,
+        "internalType": "uint256[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RegisteredAndClaimedByEmail",
+    "inputs": [
+      {
+        "name": "account",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "credentialId",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "username",
+        "type": "string",
+        "indexed": false,
+        "internalType": "string"
+      },
+      {
+        "name": "emailHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "hatIds",
+        "type": "uint256[]",
+        "indexed": false,
+        "internalType": "uint256[]"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RoleClaimedByDomain",
+    "inputs": [
+      {
+        "name": "claimer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "domainHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "hatIds",
+        "type": "uint256[]",
+        "indexed": false,
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "nullifier",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "RoleClaimedByEmail",
+    "inputs": [
+      {
+        "name": "claimer",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "emailHash",
+        "type": "bytes32",
+        "indexed": true,
+        "internalType": "bytes32"
+      },
+      {
+        "name": "hatIds",
+        "type": "uint256[]",
+        "indexed": false,
+        "internalType": "uint256[]"
+      },
+      {
+        "name": "nullifier",
+        "type": "bytes32",
+        "indexed": false,
+        "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "UniversalFactoryUpdated",
+    "inputs": [
+      {
+        "name": "factory",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "error",
+    "name": "AllowlistNotActive",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "EmptyHats",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidDKIMKey",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidInitialization",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "InvalidProof",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInAllowlist",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NotInitializing",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "NullifierAlreadyUsed",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "PasskeyFactoryNotSet",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ReentrancyGuardReentrantCall",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "Unauthorized",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroAddress",
+    "inputs": []
+  },
+  {
+    "type": "error",
+    "name": "ZeroClaimer",
+    "inputs": []
+  }
+]

--- a/pop-subgraph/schema.graphql
+++ b/pop-subgraph/schema.graphql
@@ -12,6 +12,7 @@ type Organization @entity(immutable: false) {
   paymentManager: PaymentManagerContract
   eligibilityModule: EligibilityModuleContract
   toggleModuleContract: ToggleModuleContract
+  zkEmailInvites: ZkEmailInvites
   # Deployment data - nullable until OrgDeployed event
   topHatId: BigInt
   roleHatIds: [BigInt!]
@@ -1102,6 +1103,51 @@ type EducationHubHatsChange @entity(immutable: true) {
   changedAt: BigInt!
   changedAtBlock: BigInt!
   transactionHash: Bytes!
+}
+
+# ========================================
+# ZkEmailInvites Contract and Related Entities
+# ========================================
+
+# Per-org ZkEmailInvites module (proxy, registered in OrgRegistry like EducationHub).
+# Holds the currently-active "allowed emails" allowlist: a JSON file on IPFS mapping whole
+# domains + specific emails -> role hat IDs, committed on-chain by a merkle root.
+type ZkEmailInvites @entity(immutable: false) {
+  id: Bytes! # proxy address
+  organization: Organization!
+  # Active allowlist merkle root committed on-chain (null/dormant when no allowlist is set).
+  activeRoot: Bytes
+  # CIDv0 of the active allowlist JSON on IPFS (derived from the bytes32 allowlistCid digest).
+  # Null when the allowlist is cleared (dormant).
+  activeAllowlistCid: String
+  # The indexed content of the active allowlist (may be null if IPFS is slow/unavailable).
+  activeAllowlist: ZkEmailAllowlist
+  createdAt: BigInt
+  lastUpdatedAt: BigInt
+}
+
+# IPFS-indexed content of a single allowlist commit, keyed by its CIDv0.
+type ZkEmailAllowlist @entity(immutable: false) {
+  id: String! # IPFS CIDv0 of the allowlist JSON
+  module: ZkEmailInvites!
+  # Merkle root declared inside the allowlist JSON (should match the on-chain commit).
+  root: Bytes
+  entries: [ZkEmailAllowlistEntry!]! @derivedFrom(field: "allowlist")
+  indexedAt: BigInt
+}
+
+# A single allowlist entry: either a whole domain or a specific email mapped to role hat IDs.
+type ZkEmailAllowlistEntry @entity(immutable: true) {
+  id: String! # cid-index
+  allowlist: ZkEmailAllowlist!
+  entryType: String! # "domain" or "email"
+  # The human-readable identifier ("anthropic.com" for a domain, "alice@org.com" for an email).
+  identifier: String
+  # For email entries, the keccak/poseidon emailHash committed in the JSON (null for domains).
+  identifierHash: Bytes
+  hatIds: [BigInt!]! # role hat IDs granted by this entry
+  roleIndexes: [Int!]! # role indexes parallel to hatIds
+  index: Int! # position in the entries[] array
 }
 
 # ========================================

--- a/pop-subgraph/src/org-registry.ts
+++ b/pop-subgraph/src/org-registry.ts
@@ -1,4 +1,4 @@
-import { BigInt, Bytes, DataSourceContext } from "@graphprotocol/graph-ts";
+import { Address, BigInt, Bytes, DataSourceContext } from "@graphprotocol/graph-ts";
 import {
   OrgRegistered as OrgRegisteredEvent,
   MetaUpdated as MetaUpdatedEvent,
@@ -12,11 +12,27 @@ import {
   OrgMetaUpdate,
   OrgMetadata,
   RegisteredContract,
-  SwitchableBeaconContract
+  SwitchableBeaconContract,
+  EducationHubContract,
+  ParticipationTokenContract
 } from "../generated/schema";
 import { SwitchableBeacon as SwitchableBeaconTemplate } from "../generated/templates";
 import { OrgMetadata as OrgMetadataTemplate } from "../generated/templates";
+import { EducationHub as EducationHubTemplate } from "../generated/templates";
 import { getOrCreateRole } from "./utils";
+
+// 20-byte zero address. Optional module pointers (e.g. Organization.educationHub) are set to the
+// zero-address entity at deploy time when the module was not deployed with the org.
+const ZERO_ADDRESS: Bytes = Bytes.fromHexString("0x0000000000000000000000000000000000000000");
+
+// keccak256("EducationHub") — the OrgRegistry typeId for the EducationHub module.
+// EducationHub is the only module that is OPTIONAL at org-deployment time
+// (ModulesFactory.EducationHubConfig.enabled); every other module is always deployed, and
+// OrgRegistry.registerOrgContract reverts `TypeTaken` for an already-registered type. So the
+// post-deployment registration path can only ever introduce an EducationHub today.
+const EDUCATION_HUB_TYPE_ID: Bytes = Bytes.fromHexString(
+  "0xa871f070b566fe185ede7c7d071cb2f92e7c75c6a2912b6f37c86a50cdc6bad3"
+);
 
 /**
  * Helper function to convert bytes32 sha256 digest to IPFS CIDv0.
@@ -243,6 +259,76 @@ export function handleContractRegistered(event: ContractRegisteredEvent): void {
 
   // Create dynamic data source to index SwitchableBeacon events
   SwitchableBeaconTemplate.create(beacon);
+
+  // Wire any module that is added to the org AFTER initial deployment (e.g. an EducationHub
+  // enabled via governance later). handleOrgDeployed only wires modules present at deploy time, so
+  // without this a post-hoc registration leaves Organization.educationHub pointing at the zero
+  // entity and the module's events never index.
+  wirePostDeployModule(orgId, typeId, proxy, event);
+}
+
+/**
+ * Wire a module registered AFTER the org's initial deployment into its typed Organization pointer
+ * and spin up its data-source template. No-op during the initial-deployment transaction (that is
+ * handled by handleOrgDeployed) and idempotent for modules already wired.
+ *
+ * Why this is keyed on typeId rather than handling every module: registerOrgContract reverts
+ * `TypeTaken` once a (orgId, typeId) pair is registered, so the only module that can legitimately
+ * arrive through this path is one that was absent at deploy. EducationHub is the sole optional
+ * module today; additional optional modules can be added as `else if` branches below.
+ */
+function wirePostDeployModule(orgId: Bytes, typeId: Bytes, proxy: Bytes, event: ContractRegisteredEvent): void {
+  let org = Organization.load(orgId);
+  // deployedAtBlock is null until handleOrgDeployed runs. Guarding on it makes this robust to the
+  // event ordering inside the deployment tx: if ContractRegistered fires before OrgDeployed we skip
+  // (OrgDeployed will wire the module + template), avoiding a duplicate dynamic data source.
+  if (org == null || org.deployedAtBlock === null) {
+    return;
+  }
+
+  if (typeId.equals(EDUCATION_HUB_TYPE_ID)) {
+    // Idempotent: if the org already points at a real (non-zero) EducationHub, do nothing.
+    let current = org.educationHub;
+    if (current !== null && !changetype<Bytes>(current).equals(ZERO_ADDRESS)) {
+      return;
+    }
+
+    // The module's own initializer events (TokenSet/HatsSet/ExecutorSet) were emitted before this
+    // proxy's template exists, so they will not backfill. Seed the entity from known org context
+    // instead; handleTokenSet/HatsSet/ExecutorSet will keep it current from here on.
+    let eduHub = new EducationHubContract(proxy);
+    eduHub.organization = org.id;
+    eduHub.token = org.participationToken !== null ? changetype<Bytes>(org.participationToken) : ZERO_ADDRESS;
+    eduHub.executor = org.executorContract !== null ? changetype<Bytes>(org.executorContract) : ZERO_ADDRESS;
+    eduHub.hatsContract = resolveOrgHats(org);
+    eduHub.isPaused = false;
+    eduHub.nextModuleId = BigInt.fromI32(0);
+    eduHub.createdAt = event.block.timestamp;
+    eduHub.createdAtBlock = event.block.number;
+    eduHub.save();
+
+    org.educationHub = proxy;
+    org.lastUpdatedAt = event.block.timestamp;
+    org.save();
+
+    // Index the module's modules/completions/permission changes from this block forward.
+    EducationHubTemplate.create(Address.fromBytes(proxy));
+  }
+}
+
+/**
+ * Best-effort lookup of the org's Hats Protocol address from an already-indexed module entity.
+ * Falls back to the zero address (handleHatsSet will correct it if setHats is ever called).
+ */
+function resolveOrgHats(org: Organization): Bytes {
+  let pt = org.participationToken;
+  if (pt !== null) {
+    let ptc = ParticipationTokenContract.load(changetype<Bytes>(pt));
+    if (ptc != null && !ptc.hatsContract.equals(ZERO_ADDRESS)) {
+      return ptc.hatsContract;
+    }
+  }
+  return ZERO_ADDRESS;
 }
 
 /**

--- a/pop-subgraph/src/org-registry.ts
+++ b/pop-subgraph/src/org-registry.ts
@@ -14,11 +14,13 @@ import {
   RegisteredContract,
   SwitchableBeaconContract,
   EducationHubContract,
-  ParticipationTokenContract
+  ParticipationTokenContract,
+  ZkEmailInvites
 } from "../generated/schema";
 import { SwitchableBeacon as SwitchableBeaconTemplate } from "../generated/templates";
 import { OrgMetadata as OrgMetadataTemplate } from "../generated/templates";
 import { EducationHub as EducationHubTemplate } from "../generated/templates";
+import { ZkEmailInvites as ZkEmailInvitesTemplate } from "../generated/templates";
 import { getOrCreateRole } from "./utils";
 
 // 20-byte zero address. Optional module pointers (e.g. Organization.educationHub) are set to the
@@ -32,6 +34,13 @@ const ZERO_ADDRESS: Bytes = Bytes.fromHexString("0x00000000000000000000000000000
 // post-deployment registration path can only ever introduce an EducationHub today.
 const EDUCATION_HUB_TYPE_ID: Bytes = Bytes.fromHexString(
   "0xa871f070b566fe185ede7c7d071cb2f92e7c75c6a2912b6f37c86a50cdc6bad3"
+);
+
+// keccak256("ZkEmailInvites") — the OrgRegistry typeId for the per-org ZkEmailInvites module.
+// Mirrors ModuleTypes.ZKEMAIL_INVITES_ID in the contracts repo. Like EducationHub, this module
+// is registered via OrgRegistry.ContractRegistered, so it flows through wirePostDeployModule.
+const ZKEMAIL_INVITES_ID: Bytes = Bytes.fromHexString(
+  "0x77a52db12b54c70a33bdf184cac221a69b235b98cf754315952afcffd06ae4db"
 );
 
 /**
@@ -279,10 +288,38 @@ export function handleContractRegistered(event: ContractRegisteredEvent): void {
  */
 function wirePostDeployModule(orgId: Bytes, typeId: Bytes, proxy: Bytes, event: ContractRegisteredEvent): void {
   let org = Organization.load(orgId);
+  if (org == null) {
+    return;
+  }
+
+  if (typeId.equals(ZKEMAIL_INVITES_ID)) {
+    // ZkEmailInvites is NOT one of the fixed modules carried by OrgDeployed, so this
+    // ContractRegistered is the ONLY place it can be wired — regardless of whether OrgDeployed has
+    // run yet (no deployedAtBlock guard). The proxy is registered BEFORE its initialize() runs (see
+    // ModulesFactory / the governance batch), so creating the data-source template here captures the
+    // init-time ActiveAllowlistSet that handleActiveAllowlistSet then indexes. No risk of a duplicate
+    // data source because OrgDeployed never spawns a ZkEmailInvites template.
+    let existing = ZkEmailInvites.load(proxy);
+    if (existing == null) {
+      let zk = new ZkEmailInvites(proxy);
+      zk.organization = org.id;
+      zk.createdAt = event.block.timestamp;
+      zk.lastUpdatedAt = event.block.timestamp;
+      zk.save();
+
+      org.zkEmailInvites = proxy;
+      org.lastUpdatedAt = event.block.timestamp;
+      org.save();
+
+      ZkEmailInvitesTemplate.create(Address.fromBytes(proxy));
+    }
+    return;
+  }
+
   // deployedAtBlock is null until handleOrgDeployed runs. Guarding on it makes this robust to the
   // event ordering inside the deployment tx: if ContractRegistered fires before OrgDeployed we skip
   // (OrgDeployed will wire the module + template), avoiding a duplicate dynamic data source.
-  if (org == null || org.deployedAtBlock === null) {
+  if (org.deployedAtBlock === null) {
     return;
   }
 

--- a/pop-subgraph/src/zk-email-allowlist.ts
+++ b/pop-subgraph/src/zk-email-allowlist.ts
@@ -1,0 +1,202 @@
+import { Bytes, dataSource, json, BigInt, JSONValueKind, ByteArray } from "@graphprotocol/graph-ts";
+import { ZkEmailAllowlist, ZkEmailAllowlistEntry, ZkEmailInvites } from "../generated/schema";
+
+/**
+ * Handler for the IPFS file data source that parses a ZkEmailInvites allowlist JSON.
+ *
+ * Expected JSON structure (schema "poa.zkemail.allowlist/1"):
+ * {
+ *   "schema": "poa.zkemail.allowlist/1",
+ *   "orgId": "0x..",
+ *   "root": "0x..",
+ *   "entries": [
+ *     { "type": "domain", "identifier": "anthropic.com", "hatIds": ["0x.."], "roleIndexes": [0] },
+ *     { "type": "email",  "identifier": "alice@org.com", "emailHash": "0x..",
+ *       "hatIds": ["0x.."], "roleIndexes": [1] }
+ *   ]
+ * }
+ *
+ * Mirrors org-metadata.ts: resilient to malformed data (the subgraph never bricks if IPFS is slow
+ * or the JSON is bad — on-chain ZkEmailInvites indexing continues), dedupes on the CID because the
+ * ZkEmailAllowlistEntry children are immutable, and links the parsed content back to the module via
+ * the DataSourceContext "module" key set in zk-email-invites.ts.
+ */
+export function handleZkEmailAllowlist(content: Bytes): void {
+  // dataSource.stringParam() is the IPFS CIDv0 (this entity's id).
+  let cid = dataSource.stringParam();
+
+  // Module proxy address passed by the spawning ActiveAllowlistSet handler.
+  let context = dataSource.context();
+  let moduleAddress = context.getBytes("module");
+
+  // Immutable children — if this CID was already indexed, do nothing (avoids INSERT conflicts).
+  let existing = ZkEmailAllowlist.load(cid);
+  if (existing != null) {
+    linkActive(moduleAddress, cid);
+    return;
+  }
+
+  // Create the allowlist entity up front so the back-link survives even if JSON parsing fails.
+  let allowlist = new ZkEmailAllowlist(cid);
+  allowlist.module = moduleAddress;
+  // File data sources have no block context; use 0 as a placeholder (same as org-metadata.ts).
+  allowlist.indexedAt = BigInt.fromI32(0);
+
+  let jsonResult = json.try_fromBytes(content);
+  if (jsonResult.isError) {
+    allowlist.save();
+    linkActive(moduleAddress, cid);
+    return;
+  }
+
+  let jsonValue = jsonResult.value;
+  if (jsonValue.isNull() || jsonValue.kind != JSONValueKind.OBJECT) {
+    allowlist.save();
+    linkActive(moduleAddress, cid);
+    return;
+  }
+
+  let obj = jsonValue.toObject();
+
+  // Parse the declared merkle root (should match the on-chain commit).
+  let rootValue = obj.get("root");
+  if (rootValue != null && !rootValue.isNull() && rootValue.kind == JSONValueKind.STRING) {
+    let rootStr = rootValue.toString();
+    if (rootStr.length > 0) {
+      allowlist.root = parseHexToBytes(rootStr);
+    }
+  }
+
+  allowlist.save();
+  linkActive(moduleAddress, cid);
+
+  // Parse entries[] — each becomes an immutable ZkEmailAllowlistEntry keyed by "cid-index".
+  let entriesValue = obj.get("entries");
+  if (entriesValue == null || entriesValue.isNull() || entriesValue.kind != JSONValueKind.ARRAY) {
+    return;
+  }
+
+  let entriesArray = entriesValue.toArray();
+  for (let i = 0; i < entriesArray.length; i++) {
+    let entryValue = entriesArray[i];
+    if (entryValue.isNull() || entryValue.kind != JSONValueKind.OBJECT) {
+      continue;
+    }
+    let entryObj = entryValue.toObject();
+
+    let entry = new ZkEmailAllowlistEntry(cid + "-" + i.toString());
+    entry.allowlist = cid;
+    entry.index = i;
+
+    // type — "domain" or "email"; default to "domain" if absent so the field stays non-null.
+    let typeValue = entryObj.get("type");
+    if (typeValue != null && !typeValue.isNull() && typeValue.kind == JSONValueKind.STRING) {
+      entry.entryType = typeValue.toString();
+    } else {
+      entry.entryType = "domain";
+    }
+
+    // identifier — "anthropic.com" or "alice@org.com" (optional).
+    let identifierValue = entryObj.get("identifier");
+    if (identifierValue != null && !identifierValue.isNull() && identifierValue.kind == JSONValueKind.STRING) {
+      entry.identifier = identifierValue.toString();
+    }
+
+    // identifierHash — from "emailHash" for email entries (domains have no hash in the schema).
+    let emailHashValue = entryObj.get("emailHash");
+    if (emailHashValue != null && !emailHashValue.isNull() && emailHashValue.kind == JSONValueKind.STRING) {
+      let emailHashStr = emailHashValue.toString();
+      if (emailHashStr.length > 0) {
+        entry.identifierHash = parseHexToBytes(emailHashStr);
+      }
+    }
+
+    // hatIds — array of big-endian uint256 hex strings -> BigInt[].
+    let hatIds: BigInt[] = [];
+    let hatIdsValue = entryObj.get("hatIds");
+    if (hatIdsValue != null && !hatIdsValue.isNull() && hatIdsValue.kind == JSONValueKind.ARRAY) {
+      let hatIdsArray = hatIdsValue.toArray();
+      for (let h = 0; h < hatIdsArray.length; h++) {
+        let hv = hatIdsArray[h];
+        if (hv.isNull()) {
+          continue;
+        }
+        if (hv.kind == JSONValueKind.STRING) {
+          let hatStr = hv.toString();
+          if (hatStr.length > 0) {
+            hatIds.push(parseHexToBigInt(hatStr));
+          }
+        } else if (hv.kind == JSONValueKind.NUMBER) {
+          hatIds.push(hv.toBigInt());
+        }
+      }
+    }
+    entry.hatIds = hatIds;
+
+    // roleIndexes — parallel array of small ints.
+    let roleIndexes: i32[] = [];
+    let roleIndexesValue = entryObj.get("roleIndexes");
+    if (roleIndexesValue != null && !roleIndexesValue.isNull() && roleIndexesValue.kind == JSONValueKind.ARRAY) {
+      let roleIndexesArray = roleIndexesValue.toArray();
+      for (let r = 0; r < roleIndexesArray.length; r++) {
+        let rv = roleIndexesArray[r];
+        if (!rv.isNull() && rv.kind == JSONValueKind.NUMBER) {
+          roleIndexes.push(rv.toBigInt().toI32());
+        }
+      }
+    }
+    entry.roleIndexes = roleIndexes;
+
+    entry.save();
+  }
+}
+
+/**
+ * Back-link the module's activeAllowlist pointer to this CID, but only if it is still the active one
+ * (a newer ActiveAllowlistSet may have superseded it before the IPFS file landed).
+ */
+function linkActive(moduleAddress: Bytes, cid: string): void {
+  let module = ZkEmailInvites.load(moduleAddress);
+  if (module == null) {
+    return;
+  }
+  let activeCid = module.activeAllowlistCid;
+  if (activeCid === null) {
+    return;
+  }
+  let activeCidStr: string = activeCid;
+  if (activeCidStr == cid) {
+    module.activeAllowlist = cid;
+    module.save();
+  }
+}
+
+/**
+ * Parse a (possibly "0x"-prefixed) big-endian hex string into Bytes. Callers guard against empty
+ * input. Uses charAt + substring (startsWith/substr have crashed this AS toolchain).
+ */
+function parseHexToBytes(hex: string): Bytes {
+  let normalized = hex;
+  if (normalized.length >= 2) {
+    let c0 = normalized.charAt(0);
+    let c1 = normalized.charAt(1);
+    if (c0 == "0" && (c1 == "x" || c1 == "X")) {
+      normalized = normalized.substring(2);
+    }
+  }
+  // Bytes.fromHexString needs an even number of nibbles.
+  if (normalized.length % 2 != 0) {
+    normalized = "0" + normalized;
+  }
+  return Bytes.fromHexString("0x" + normalized);
+}
+
+/**
+ * Parse a big-endian uint256 hex string into a BigInt. graph-ts BigInt is little-endian, so reverse
+ * the big-endian bytes before fromUnsignedBytes. Callers guard against empty input.
+ */
+function parseHexToBigInt(hex: string): BigInt {
+  let bytes = parseHexToBytes(hex);
+  let reversed = Bytes.fromUint8Array(changetype<ByteArray>(bytes).reverse());
+  return BigInt.fromUnsignedBytes(reversed);
+}

--- a/pop-subgraph/src/zk-email-invites.ts
+++ b/pop-subgraph/src/zk-email-invites.ts
@@ -1,0 +1,119 @@
+import { Address, BigInt, Bytes, DataSourceContext } from "@graphprotocol/graph-ts";
+import {
+  ActiveAllowlistSet as ActiveAllowlistSetEvent,
+  RoleClaimedByDomain as RoleClaimedByDomainEvent,
+  RoleClaimedByEmail as RoleClaimedByEmailEvent
+} from "../generated/templates/ZkEmailInvites/ZkEmailInvites";
+import { ZkEmailInvites } from "../generated/schema";
+import { ZkEmailAllowlist as ZkEmailAllowlistTemplate } from "../generated/templates";
+
+// 32-byte zero digest. A zero allowlistCid means the allowlist was cleared (the module is dormant).
+const ZERO_HASH: Bytes = Bytes.fromHexString("0x0000000000000000000000000000000000000000000000000000000000000000");
+
+/**
+ * Convert a bytes32 sha256 digest to an IPFS CIDv0 string.
+ *
+ * CIDv0 = base58( 0x1220 + sha256_digest )
+ * - 0x12 = sha2-256 multicodec
+ * - 0x20 = 32 bytes length
+ * - sha256_digest = the bytes32 emitted by the contract
+ *
+ * Mirrors bytes32ToCid in org-registry.ts / education-hub.ts.
+ */
+function bytes32ToCid(hash: Bytes): string {
+  let prefix = Bytes.fromHexString("0x1220");
+  let multihash = new Bytes(34);
+  for (let i = 0; i < 2; i++) {
+    multihash[i] = prefix[i];
+  }
+  for (let i = 0; i < 32; i++) {
+    multihash[i + 2] = hash[i];
+  }
+  return multihash.toBase58();
+}
+
+/**
+ * Spawn an IPFS file data source over the active allowlist CID. Carries the module proxy address in
+ * a DataSourceContext so handleZkEmailAllowlist can link the parsed content back to the module.
+ * Mirrors createIpfsDataSource in org-registry.ts (zero-hash skip + dedupe-by-CID).
+ */
+function createAllowlistDataSource(allowlistHash: Bytes, moduleAddress: Bytes): string {
+  let ipfsCid = bytes32ToCid(allowlistHash);
+
+  // Pass the module address so the file handler can set ZkEmailAllowlist.module + back-link
+  // ZkEmailInvites.activeAllowlist. The file handler dedupes on the CID for immutable children.
+  let context = new DataSourceContext();
+  context.setBytes("module", moduleAddress);
+
+  ZkEmailAllowlistTemplate.createWithContext(ipfsCid, context);
+  return ipfsCid;
+}
+
+/**
+ * ActiveAllowlistSet(bytes32 indexed merkleRoot, bytes32 indexed allowlistCid).
+ * Emitted at initialize() and whenever a new allowlist is committed (or cleared, with a zero CID).
+ */
+export function handleActiveAllowlistSet(event: ActiveAllowlistSetEvent): void {
+  let moduleAddress = event.address;
+  let merkleRoot = event.params.merkleRoot;
+  let allowlistCid = event.params.allowlistCid;
+
+  // The ZkEmailInvites entity is created in org-registry.ts when the proxy is registered, which the
+  // contract guarantees happens BEFORE initialize() emits this event (register-before-initialize, so
+  // the data-source template exists in time to catch the init-time ActiveAllowlistSet). We therefore
+  // never need to fabricate the entity here — and must not, since `organization` is required and is
+  // only known to the registration handler. If it is somehow missing, skip rather than brick.
+  let module = ZkEmailInvites.load(moduleAddress);
+  if (module == null) {
+    return;
+  }
+
+  // A zero CID means the allowlist was cleared: the module is dormant, no file source to spawn.
+  if (allowlistCid.equals(ZERO_HASH)) {
+    module.activeRoot = null;
+    module.activeAllowlistCid = null;
+    module.activeAllowlist = null;
+    module.lastUpdatedAt = event.block.timestamp;
+    module.save();
+    return;
+  }
+
+  let cid = bytes32ToCid(allowlistCid);
+  module.activeRoot = merkleRoot;
+  module.activeAllowlistCid = cid;
+  // Link to the ZkEmailAllowlist entity (populated once the IPFS content is indexed).
+  module.activeAllowlist = cid;
+  module.lastUpdatedAt = event.block.timestamp;
+  module.save();
+
+  // Fetch + index the allowlist JSON. Resilient: if IPFS is slow/unavailable, on-chain indexing
+  // continues and activeAllowlist simply resolves null until the file lands.
+  createAllowlistDataSource(allowlistCid, moduleAddress);
+}
+
+/**
+ * RoleClaimedByDomain(address indexed claimer, bytes32 indexed domainHash, uint256[] hatIds, bytes32 nullifier).
+ * Membership itself is indexed from the Hats TransferSingle/Batch handler; here we only freshen the
+ * module's lastUpdatedAt so consumers can see recent activity.
+ */
+export function handleRoleClaimedByDomain(event: RoleClaimedByDomainEvent): void {
+  let module = ZkEmailInvites.load(event.address);
+  if (module == null) {
+    return;
+  }
+  module.lastUpdatedAt = event.block.timestamp;
+  module.save();
+}
+
+/**
+ * RoleClaimedByEmail(address indexed claimer, bytes32 indexed emailHash, uint256[] hatIds, bytes32 nullifier).
+ * Light-touch like handleRoleClaimedByDomain — membership comes from the Hats handler.
+ */
+export function handleRoleClaimedByEmail(event: RoleClaimedByEmailEvent): void {
+  let module = ZkEmailInvites.load(event.address);
+  if (module == null) {
+    return;
+  }
+  module.lastUpdatedAt = event.block.timestamp;
+  module.save();
+}

--- a/pop-subgraph/subgraph.yaml
+++ b/pop-subgraph/subgraph.yaml
@@ -702,6 +702,30 @@ templates:
           handler: handleUnpaused
       file: ./src/education-hub.ts
   - kind: ethereum
+    name: ZkEmailInvites
+    network: gnosis
+    source:
+      abi: ZkEmailInvites
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      entities:
+        - ZkEmailInvites
+        - ZkEmailAllowlist
+        - ZkEmailAllowlistEntry
+      abis:
+        - name: ZkEmailInvites
+          file: ./abis/ZkEmailInvites.json
+      eventHandlers:
+        - event: ActiveAllowlistSet(indexed bytes32,indexed bytes32)
+          handler: handleActiveAllowlistSet
+        - event: RoleClaimedByDomain(indexed address,indexed bytes32,uint256[],bytes32)
+          handler: handleRoleClaimedByDomain
+        - event: RoleClaimedByEmail(indexed address,indexed bytes32,uint256[],bytes32)
+          handler: handleRoleClaimedByEmail
+      file: ./src/zk-email-invites.ts
+  - kind: ethereum
     name: PaymentManager
     network: gnosis
     source:
@@ -989,6 +1013,21 @@ templates:
       abis:
         - name: EducationHub
           file: ./abis/EducationHub.json
+  - kind: file/ipfs
+    name: ZkEmailAllowlist
+    network: gnosis
+    mapping:
+      apiVersion: 0.0.9
+      language: wasm/assemblyscript
+      file: ./src/zk-email-allowlist.ts
+      handler: handleZkEmailAllowlist
+      entities:
+        - ZkEmailAllowlist
+        - ZkEmailAllowlistEntry
+        - ZkEmailInvites
+      abis:
+        - name: ZkEmailInvites
+          file: ./abis/ZkEmailInvites.json
   - kind: file/ipfs
     name: TokenRequestMetadata
     network: gnosis

--- a/pop-subgraph/tests/org-registry.test.ts
+++ b/pop-subgraph/tests/org-registry.test.ts
@@ -32,6 +32,25 @@ import {
 // Default mock event address from matchstick
 const REGISTRY_ADDRESS = "0xa16081f360e3847006db660bae1c6d1b2e17ec2a";
 
+// keccak256("EducationHub") — OrgRegistry typeId for the optional EducationHub module.
+const EDUCATION_HUB_TYPE_ID = "0xa871f070b566fe185ede7c7d071cb2f92e7c75c6a2912b6f37c86a50cdc6bad3";
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+// Helper: org deployed WITHOUT an EducationHub (educationHub points at the zero entity),
+// mirroring a real org like Decentral Park. `deployed` toggles whether OrgDeployed has run yet
+// (deployedAtBlock is null until it has).
+function createOrgWithoutEduHub(orgId: Bytes, deployed: boolean): void {
+  let org = new Organization(orgId);
+  org.executorContract = Bytes.fromHexString("0x0000000000000000000000000000000000000001");
+  org.participationToken = Bytes.fromHexString("0x0000000000000000000000000000000000000005");
+  org.educationHub = Bytes.fromHexString(ZERO_ADDRESS);
+  if (deployed) {
+    org.deployedAt = BigInt.fromI32(1000);
+    org.deployedAtBlock = BigInt.fromI32(100);
+  }
+  org.save();
+}
+
 /**
  * Helper function to convert bytes32 sha256 digest to IPFS CIDv0.
  * Mirrors the logic in org-registry.ts for test assertions.
@@ -441,6 +460,111 @@ describe("OrgRegistry", () => {
         "totalContracts",
         "2"
       );
+    });
+  });
+
+  describe("handleContractRegistered - post-deploy module wiring", () => {
+    test("wires Organization.educationHub + creates entity for a post-deploy EducationHub", () => {
+      let orgId = Bytes.fromHexString(
+        "0x1111111111111111111111111111111111111111111111111111111111111111"
+      );
+      let contractId = Bytes.fromHexString(
+        "0x7777777777777777777777777777777777777777777777777777777777777777"
+      );
+      let eduTypeId = Bytes.fromHexString(EDUCATION_HUB_TYPE_ID);
+      let proxy = Address.fromString("0x00000000000000000000000000000000000000ee");
+      let beacon = Address.fromString("0x00000000000000000000000000000000000000bb");
+      let owner = Address.fromString("0x0000000000000000000000000000000000000001");
+
+      // Org deployed without an EducationHub (the Decentral Park case).
+      createOrgWithoutEduHub(orgId, true);
+
+      let ev = createContractRegisteredEvent(contractId, orgId, eduTypeId, proxy, beacon, true, owner);
+      ev.logIndex = BigInt.fromI32(2);
+      handleContractRegistered(ev);
+
+      // The typed pointer the frontend reads now resolves to the new proxy.
+      assert.fieldEquals("Organization", orgId.toHexString(), "educationHub", proxy.toHexString());
+
+      // The referenced EducationHubContract entity exists, seeded from org context.
+      assert.entityCount("EducationHubContract", 1);
+      assert.fieldEquals("EducationHubContract", proxy.toHexString(), "organization", orgId.toHexString());
+      assert.fieldEquals(
+        "EducationHubContract",
+        proxy.toHexString(),
+        "executor",
+        "0x0000000000000000000000000000000000000001"
+      );
+      assert.fieldEquals(
+        "EducationHubContract",
+        proxy.toHexString(),
+        "token",
+        "0x0000000000000000000000000000000000000005"
+      );
+      assert.fieldEquals("EducationHubContract", proxy.toHexString(), "nextModuleId", "0");
+
+      // The generic RegisteredContract row is still written.
+      assert.entityCount("RegisteredContract", 1);
+    });
+
+    test("is idempotent - does not overwrite an already-wired EducationHub", () => {
+      let orgId = Bytes.fromHexString(
+        "0x1111111111111111111111111111111111111111111111111111111111111111"
+      );
+      let contractId = Bytes.fromHexString(
+        "0x7777777777777777777777777777777777777777777777777777777777777777"
+      );
+      let eduTypeId = Bytes.fromHexString(EDUCATION_HUB_TYPE_ID);
+      let proxy = Address.fromString("0x00000000000000000000000000000000000000ee");
+      let beacon = Address.fromString("0x00000000000000000000000000000000000000bb");
+      let owner = Address.fromString("0x0000000000000000000000000000000000000001");
+
+      // Org already has a real EducationHub (e.g. it was deployed with one).
+      let org = new Organization(orgId);
+      org.executorContract = Bytes.fromHexString("0x0000000000000000000000000000000000000001");
+      org.participationToken = Bytes.fromHexString("0x0000000000000000000000000000000000000005");
+      org.educationHub = Bytes.fromHexString("0x00000000000000000000000000000000000000aa");
+      org.deployedAtBlock = BigInt.fromI32(100);
+      org.save();
+
+      let ev = createContractRegisteredEvent(contractId, orgId, eduTypeId, proxy, beacon, true, owner);
+      ev.logIndex = BigInt.fromI32(2);
+      handleContractRegistered(ev);
+
+      // Pointer is unchanged and no new module entity is fabricated.
+      assert.fieldEquals(
+        "Organization",
+        orgId.toHexString(),
+        "educationHub",
+        "0x00000000000000000000000000000000000000aa"
+      );
+      assert.entityCount("EducationHubContract", 0);
+    });
+
+    test("skips wiring during initial deployment (deployedAtBlock null)", () => {
+      let orgId = Bytes.fromHexString(
+        "0x1111111111111111111111111111111111111111111111111111111111111111"
+      );
+      let contractId = Bytes.fromHexString(
+        "0x7777777777777777777777777777777777777777777777777777777777777777"
+      );
+      let eduTypeId = Bytes.fromHexString(EDUCATION_HUB_TYPE_ID);
+      let proxy = Address.fromString("0x00000000000000000000000000000000000000ee");
+      let beacon = Address.fromString("0x00000000000000000000000000000000000000bb");
+      let owner = Address.fromString("0x0000000000000000000000000000000000000001");
+
+      // OrgDeployed has not run yet (deployedAtBlock null); it will wire the module + template.
+      createOrgWithoutEduHub(orgId, false);
+
+      let ev = createContractRegisteredEvent(contractId, orgId, eduTypeId, proxy, beacon, true, owner);
+      ev.logIndex = BigInt.fromI32(2);
+      handleContractRegistered(ev);
+
+      // Pointer stays at the zero entity; no module entity created here.
+      assert.fieldEquals("Organization", orgId.toHexString(), "educationHub", ZERO_ADDRESS);
+      assert.entityCount("EducationHubContract", 0);
+      // The generic RegisteredContract row is still written regardless.
+      assert.entityCount("RegisteredContract", 1);
     });
   });
 

--- a/pop-subgraph/tests/zk-email-invites-utils.ts
+++ b/pop-subgraph/tests/zk-email-invites-utils.ts
@@ -1,0 +1,80 @@
+import { newMockEvent } from "matchstick-as";
+import { ethereum, Address, BigInt, Bytes } from "@graphprotocol/graph-ts";
+import {
+  ActiveAllowlistSet,
+  RoleClaimedByDomain,
+  RoleClaimedByEmail
+} from "../generated/templates/ZkEmailInvites/ZkEmailInvites";
+
+export function createActiveAllowlistSetEvent(
+  module: Address,
+  merkleRoot: Bytes,
+  allowlistCid: Bytes
+): ActiveAllowlistSet {
+  let event = changetype<ActiveAllowlistSet>(newMockEvent());
+  event.address = module;
+
+  event.parameters = new Array();
+  event.parameters.push(
+    new ethereum.EventParam("merkleRoot", ethereum.Value.fromFixedBytes(merkleRoot))
+  );
+  event.parameters.push(
+    new ethereum.EventParam("allowlistCid", ethereum.Value.fromFixedBytes(allowlistCid))
+  );
+
+  return event;
+}
+
+export function createRoleClaimedByDomainEvent(
+  module: Address,
+  claimer: Address,
+  domainHash: Bytes,
+  hatIds: BigInt[],
+  nullifier: Bytes
+): RoleClaimedByDomain {
+  let event = changetype<RoleClaimedByDomain>(newMockEvent());
+  event.address = module;
+
+  event.parameters = new Array();
+  event.parameters.push(
+    new ethereum.EventParam("claimer", ethereum.Value.fromAddress(claimer))
+  );
+  event.parameters.push(
+    new ethereum.EventParam("domainHash", ethereum.Value.fromFixedBytes(domainHash))
+  );
+  event.parameters.push(
+    new ethereum.EventParam("hatIds", ethereum.Value.fromUnsignedBigIntArray(hatIds))
+  );
+  event.parameters.push(
+    new ethereum.EventParam("nullifier", ethereum.Value.fromFixedBytes(nullifier))
+  );
+
+  return event;
+}
+
+export function createRoleClaimedByEmailEvent(
+  module: Address,
+  claimer: Address,
+  emailHash: Bytes,
+  hatIds: BigInt[],
+  nullifier: Bytes
+): RoleClaimedByEmail {
+  let event = changetype<RoleClaimedByEmail>(newMockEvent());
+  event.address = module;
+
+  event.parameters = new Array();
+  event.parameters.push(
+    new ethereum.EventParam("claimer", ethereum.Value.fromAddress(claimer))
+  );
+  event.parameters.push(
+    new ethereum.EventParam("emailHash", ethereum.Value.fromFixedBytes(emailHash))
+  );
+  event.parameters.push(
+    new ethereum.EventParam("hatIds", ethereum.Value.fromUnsignedBigIntArray(hatIds))
+  );
+  event.parameters.push(
+    new ethereum.EventParam("nullifier", ethereum.Value.fromFixedBytes(nullifier))
+  );
+
+  return event;
+}

--- a/pop-subgraph/tests/zk-email-invites.test.ts
+++ b/pop-subgraph/tests/zk-email-invites.test.ts
@@ -1,0 +1,123 @@
+import {
+  assert,
+  describe,
+  test,
+  clearStore,
+  afterEach,
+  dataSourceMock
+} from "matchstick-as/assembly/index";
+import { Address, Bytes, BigInt, DataSourceContext } from "@graphprotocol/graph-ts";
+import { handleActiveAllowlistSet } from "../src/zk-email-invites";
+import { handleZkEmailAllowlist } from "../src/zk-email-allowlist";
+import { handleContractRegistered } from "../src/org-registry";
+import { createContractRegisteredEvent } from "./org-registry-utils";
+import { createActiveAllowlistSetEvent } from "./zk-email-invites-utils";
+import { Organization, ZkEmailInvites, ZkEmailAllowlist } from "../generated/schema";
+
+const ZKEMAIL_INVITES_ID = "0x77a52db12b54c70a33bdf184cac221a69b235b98cf754315952afcffd06ae4db";
+
+const ZERO_HASH = "0x0000000000000000000000000000000000000000000000000000000000000000";
+const MODULE = "0x00000000000000000000000000000000000000ee";
+const ORG_ID = "0x1111111111111111111111111111111111111111111111111111111111111111";
+
+// Mirror bytes32ToCid in the handlers for assertions.
+function bytes32ToCid(hash: Bytes): string {
+  let prefix = Bytes.fromHexString("0x1220");
+  let multihash = new Bytes(34);
+  for (let i = 0; i < 2; i++) {
+    multihash[i] = prefix[i];
+  }
+  for (let i = 0; i < 32; i++) {
+    multihash[i + 2] = hash[i];
+  }
+  return multihash.toBase58();
+}
+
+function createOrgWithZkModule(): void {
+  let orgId = Bytes.fromHexString(ORG_ID);
+  let org = new Organization(orgId);
+  org.executorContract = Bytes.fromHexString("0x0000000000000000000000000000000000000001");
+  org.deployedAt = BigInt.fromI32(1000);
+  org.deployedAtBlock = BigInt.fromI32(100);
+  org.save();
+
+  let zk = new ZkEmailInvites(Bytes.fromHexString(MODULE));
+  zk.organization = orgId;
+  zk.createdAt = BigInt.fromI32(1000);
+  zk.lastUpdatedAt = BigInt.fromI32(1000);
+  zk.save();
+}
+
+describe("ZkEmailInvites", () => {
+  afterEach(() => {
+    clearStore();
+    dataSourceMock.resetValues();
+  });
+
+  describe("org-registry wiring", () => {
+    test("ContractRegistered with the ZkEmailInvites typeId wires the module + Organization pointer", () => {
+      let orgId = Bytes.fromHexString(ORG_ID);
+      let org = new Organization(orgId);
+      org.executorContract = Bytes.fromHexString("0x0000000000000000000000000000000000000001");
+      org.save();
+
+      let contractId = Bytes.fromHexString(
+        "0x7777777777777777777777777777777777777777777777777777777777777777"
+      );
+      let typeId = Bytes.fromHexString(ZKEMAIL_INVITES_ID);
+      let proxy = Address.fromString(MODULE);
+      let beacon = Address.fromString("0x00000000000000000000000000000000000000bb");
+      let owner = Address.fromString("0x0000000000000000000000000000000000000001");
+
+      let ev = createContractRegisteredEvent(contractId, orgId, typeId, proxy, beacon, true, owner);
+      handleContractRegistered(ev);
+
+      assert.fieldEquals("Organization", orgId.toHexString(), "zkEmailInvites", proxy.toHexString());
+      assert.entityCount("ZkEmailInvites", 1);
+      assert.fieldEquals("ZkEmailInvites", proxy.toHexString(), "organization", orgId.toHexString());
+      assert.entityCount("RegisteredContract", 1);
+    });
+  });
+
+  describe("handleActiveAllowlistSet", () => {
+    test("sets activeRoot + activeAllowlistCid and links the allowlist for a non-zero CID", () => {
+      createOrgWithZkModule();
+
+      let root = Bytes.fromHexString(
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      );
+      let cidHash = Bytes.fromHexString(
+        "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+      );
+      let expectedCid = bytes32ToCid(cidHash);
+
+      let ev = createActiveAllowlistSetEvent(Address.fromString(MODULE), root, cidHash);
+      handleActiveAllowlistSet(ev);
+
+      assert.fieldEquals("ZkEmailInvites", MODULE, "activeRoot", root.toHexString());
+      assert.fieldEquals("ZkEmailInvites", MODULE, "activeAllowlistCid", expectedCid);
+      assert.fieldEquals("ZkEmailInvites", MODULE, "activeAllowlist", expectedCid);
+    });
+
+    test("clears the active allowlist (dormant) for a zero CID", () => {
+      createOrgWithZkModule();
+
+      let root = Bytes.fromHexString(
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+      );
+      let cidHash = Bytes.fromHexString(
+        "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+      );
+      handleActiveAllowlistSet(createActiveAllowlistSetEvent(Address.fromString(MODULE), root, cidHash));
+
+      let zeroRoot = Bytes.fromHexString(ZERO_HASH);
+      let zeroCid = Bytes.fromHexString(ZERO_HASH);
+      handleActiveAllowlistSet(createActiveAllowlistSetEvent(Address.fromString(MODULE), zeroRoot, zeroCid));
+
+      let module = ZkEmailInvites.load(Bytes.fromHexString(MODULE))!;
+      assert.assertTrue(module.activeAllowlistCid === null);
+      assert.assertTrue(module.activeRoot === null);
+      assert.assertTrue(module.activeAllowlist === null);
+    });
+  });
+});

--- a/pop-subgraph/yarn.lock
+++ b/pop-subgraph/yarn.lock
@@ -390,14 +390,7 @@
   dependencies:
     "@noble/hashes" "2.0.1"
 
-"@noble/curves@~1.4.0":
-  version "1.4.2"
-  resolved "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz"
-  integrity sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==
-  dependencies:
-    "@noble/hashes" "1.4.0"
-
-"@noble/curves@1.4.2":
+"@noble/curves@~1.4.0", "@noble/curves@1.4.2":
   version "1.4.2"
   resolved "https://registry.npmjs.org/@noble/curves/-/curves-1.4.2.tgz"
   integrity sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==
@@ -2226,14 +2219,7 @@ minimatch@^10.0.3:
   dependencies:
     "@isaacs/brace-expansion" "^5.0.0"
 
-minimatch@^3.0.2:
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
-  dependencies:
-    brace-expansion "^1.1.7"
-
-minimatch@^3.1.1:
+minimatch@^3.0.2, minimatch@^3.1.1:
   version "3.1.2"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
@@ -2530,20 +2516,7 @@ react-native-fetch-api@^3.0.0:
   dependencies:
     p-defer "^3.0.0"
 
-readable-stream@^2.3.0:
-  version "2.3.8"
-  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz"
-  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
-    util-deprecate "~1.0.1"
-
-readable-stream@^2.3.5:
+readable-stream@^2.3.0, readable-stream@^2.3.5:
   version "2.3.8"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz"
   integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
@@ -2614,7 +2587,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-safe-buffer@^5.0.1, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
+safe-buffer@^5.0.1:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -2623,6 +2596,16 @@ safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-buffer@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-regex-test@^1.1.0:
   version "1.1.0"
@@ -2681,22 +2664,22 @@ shebang-regex@^3.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-signal-exit@^3.0.2:
+signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.7"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
-signal-exit@^3.0.3:
-  version "3.0.7"
-  resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
-  integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
-
-signal-exit@^4.0.1, signal-exit@^4.1.0:
+signal-exit@^4.0.1:
   version "4.1.0"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
 
-source-map-support@^0.5.20:
+signal-exit@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
+source-map-support@*, source-map-support@^0.5.20:
   version "0.5.21"
   resolved "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz"
   integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
@@ -2783,14 +2766,7 @@ strip-ansi@^5.2.0:
   dependencies:
     ansi-regex "^4.1.0"
 
-strip-ansi@^6.0.0:
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.1:
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -2916,9 +2892,9 @@ typed-array-buffer@^1.0.3:
     is-typed-array "^1.1.14"
 
 typescript@>=4.9.4:
-  version "5.9.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
-  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+  version "6.0.3"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz"
+  integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==
 
 uint8-varint@^2.0.1, uint8-varint@^2.0.2:
   version "2.0.4"


### PR DESCRIPTION
Indexes the per-org `ZkEmailInvites` module and its email **allowlist**, following the existing
org-metadata file-data-source pattern (`bytes32ToCid` + `DataSourceContext` + a `file/ipfs` template).

## What it adds
- **`Organization.zkEmailInvites`** → a `ZkEmailInvites` entity (proxy address, `activeRoot`,
  `activeAllowlistCid`, `activeAllowlist`), wired when the module proxy is registered
  (`ContractRegistered` / `OrgDeployed`, `typeId == keccak256("ZkEmailInvites")`).
- A dynamic `ethereum/contract` template (`ActiveAllowlistSet`, `RoleClaimedByDomain`,
  `RoleClaimedByEmail`) — `src/zk-email-invites.ts`.
- A `file/ipfs` template that parses the active allowlist JSON into **`ZkEmailAllowlist`** +
  **`ZkEmailAllowlistEntry`** (domain/email → role hatIds), spawned from `ActiveAllowlistSet`'s CID —
  `src/zk-email-allowlist.ts`.
- The **staged** allowlist exposed on `OrgMetadata` (`stagedAllowlistCid/Root/EntryCount`), parsed
  from the org metadata JSON.
- (Also on this branch) a fix to index **post-deploy** module additions (EducationHub) via
  `ContractRegistered`.

## Verification
`graph codegen` + `graph build` green; matchstick tests pass (270).

Companion: contracts poa-box/POP#170, frontend poa-box/Poa-frontend#455.

🤖 Generated with [Claude Code](https://claude.com/claude-code)